### PR TITLE
Add permission to concourse-user to be able to attach policy

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "policy" {
       "iam:CreateUser",
       "iam:CreateAccessKey",
       "iam:CreatePolicy",
-      "iam:AttachUserPolicy"
+      "iam:AttachUserPolicy",
     ]
 
     resources = [

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -161,6 +161,7 @@ data "aws_iam_policy_document" "policy" {
       "iam:CreateUser",
       "iam:CreateAccessKey",
       "iam:CreatePolicy",
+      "iam:AttachUserPolicy"
     ]
 
     resources = [


### PR DESCRIPTION
As part of applying the terraform modules for applications who want to request aws, concourse-user needs to have permission to attachpolicy.