### PR TITLE
added new policy to concourse user

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -162,6 +162,7 @@ data "aws_iam_policy_document" "policy" {
       "iam:CreateAccessKey",
       "iam:CreatePolicy",
       "iam:AttachUserPolicy",
+      "iam:GetPolicy",
     ]
 
     resources = [


### PR DESCRIPTION
Added permission for concourse account user can get iam policy, which is needed to be able to allow concourse user to create s3 bucket and s3 user in aws.