### PR TITLE
Adding git-crypt key to unlock secrets in CP-environments repo

### DIFF
--- a/pipelines/cloud-platform-live-0/main/build-environments.yaml
+++ b/pipelines/cloud-platform-live-0/main/build-environments.yaml
@@ -13,6 +13,7 @@ resources:
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: master
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
 - name: tools-image
   type: docker-image
   source:


### PR DESCRIPTION
Added source configuration to concourse to add allow us to add git_crypt key that will unlock the secrets in the environments repo.

