### PR TITLE
build-environments: kubeconfig should not use relative path

### DIFF
--- a/pipelines/cloud-platform-live-0/main/build-environments.yaml
+++ b/pipelines/cloud-platform-live-0/main/build-environments.yaml
@@ -55,7 +55,7 @@ jobs:
           params:
             AWS_ACCESS_KEY_ID: ((aws.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws.secret-access-key))
-            KUBECONFIG: .kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache"
           run:
             path: /bin/sh
@@ -64,7 +64,7 @@ jobs:
               - -c
               - |
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
-                aws s3 cp s3://cloud-platform-concourse-build-environments/kubeconfig .kubeconfig
+                aws s3 cp s3://cloud-platform-concourse-build-environments/kubeconfig /tmp/kubeconfig
                 ./bin/apply
         on_failure:
           put: slack-alert


### PR DESCRIPTION
Using the relative path, the kubernetes libraries cannot find authentications details so they default to a `localhost` connection. This broke the provisioning of kubernetes resources (specifically secrets) when https://github.com/ministryofjustice/cloud-platform-environments/pull/53 was merged.

The change in this PR fixes it.

reference: https://concourse.apps.cloud-platform-live-0.k8s.integration.dsd.io/teams/main/pipelines/build-environments/jobs/apply/builds/1372