### PR TITLE
Give Security Group permissions to concourse.

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -252,6 +252,25 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
 
+  statement {
+    actions = [
+      "ec2:CreateSecurityGroup",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DescribeSecurityGroupReferences",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeStaleSecurityGroups",
+      "ec2:AuthorizeSecurityGroupEgress",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:RevokeSecurityGroupEgress",
+      "ec2:RevokeSecurityGroupIngress",
+      "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+      "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "policy" {


### PR DESCRIPTION
Required by the RDS and Elasticache modules.