### PR TITLE
Add environment checker pipeline to allow weekly report

### DIFF
--- a/pipelines/cloud-platform-live-0/main/check-environment.yaml
+++ b/pipelines/cloud-platform-live-0/main/check-environment.yaml
@@ -1,0 +1,85 @@
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: master
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
+    tag: latest
+    aws_access_key_id: ((aws.access-key-id))
+    aws_secret_access_key: ((aws.secret-access-key))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-week
+  type: time
+  source:
+    interval: 10m
+    days: [Wednesday]
+    start: 16:40
+    stop: 16:50
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+jobs:
+- name: Check
+  serial: true
+  plan:
+    - aggregate:
+      - get: every-week
+        trigger: true
+      - get: cloud-platform-environments-repo
+        trigger: true
+      - get: tools-image
+    - task: check-environments
+      image: tools-image
+      config:
+        platform: linux
+        params:
+          AWS_ACCESS_KEY_ID: ((aws.access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((aws.secret-access-key))
+          KUBECONFIG: /tmp/kubeconfig
+          TF_PLUGIN_CACHE_DIR: "/tmp/terraform-plugin-cache"
+        run:
+          path: /bin/bash
+          args:
+            - -ce
+            - |
+              mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+              aws s3 cp s3://cloud-platform-concourse-build-environments/kubeconfig /tmp/kubeconfig
+              cd cloud-platform-environments-repo
+              # run script and then format output for slack notification
+              ./bin/check-inconsistent-state | tee ../results/check.txt && sed -i -e '1s/^/```\n/' -e '$a ```' -e 's/\[0;3//g' -e 's/\[0m//g' ../results/check.txt
+        inputs:
+          - name: cloud-platform-environments-repo
+        outputs:
+          - name: results
+  on_success:
+    do:
+    - put: slack-alert
+      params:
+        channel: '#cp-build-notifications'
+        text: ${TEXT_FILE_CONTENT}
+        text_file: results/check.txt
+  on_failure:
+    put: slack-alert
+    params:
+      channel: '#cp-build-notifications'
+      attachments:
+        - color: "danger"
+          fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+          title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+          title_link: 'https://concourse.apps.cloud-platform-live-0.k8s.integration.dsd.io/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+          footer: concourse.apps.cloud-platform-live-0.k8s.integration.dsd.io
+
+


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/334 and will notify slack channel #cp-build-notifications of any disparity between GitHub and the live and test clusters. Approving this PR will merge the code and nothing else. The `fly` command will need to be performed against the live-0 cluster. 

**What**
---
Single file creation to check the status of the live and test clusters and compare against the environments repo.
- `check-environment.yaml`

**Why**
---
As per https://github.com/ministryofjustice/cloud-platform/issues/334. Previously, the only time you'd know an environment was ready for deletion is word of mouth. This script and pipeline enables a notification to inform the Cloud-Platform team of any disparity. 


