### PR TITLE
Add smoke test pipeline to live-0

### DIFF
--- a/pipelines/cloud-platform-live-0/main/smoke-tests.yaml
+++ b/pipelines/cloud-platform-live-0/main/smoke-tests.yaml
@@ -1,0 +1,75 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#cp-build-notifications'
+  silent: true
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.apps.cloud-platform-live-0.k8s.integration.dsd.io/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.apps.cloud-platform-live-0.k8s.integration.dsd.io
+
+resources:
+- name: cloud-platform-smoke-tests-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-smoke-tests.git
+    branch: feature/concourse
+- name: tools-image
+  type: docker-image
+  source:
+    repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
+    tag: latest
+    aws_access_key_id: ((aws.access-key-id))
+    aws_secret_access_key: ((aws.secret-access-key))
+#- name: slack-alert
+#  type: slack-notification
+#  source:
+#    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-1hr
+  type: time
+  source:
+    interval: 1h
+
+#resource_types:
+#- name: slack-notification
+#  type: docker-image
+#  source:
+#    repository: cfcommunity/slack-notification-resource
+#    tag: latest
+
+jobs:
+  - name: smoke
+    serial: true
+    plan:
+      - aggregate:
+        - get: every-1hr
+          trigger: true
+        - get: cloud-platform-smoke-tests-repo
+          trigger: true
+        - get: tools-image
+      - task: apply-smoke-tests
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-smoke-tests-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+          run:
+            path: /bin/sh
+            dir: cloud-platform-smoke-tests-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://cloud-platform-concourse-build-environments/kubeconfig /tmp/kubeconfig
+                ./tests/00-namespace-test/test.sh
+                ./tests/01-ingress-http-traffic/test.sh
+                ./tests/02-log-collection/test.sh
+#        on_failure:
+#          put: slack-alert
+#          params:
+#            <<: *SLACK_NOTIFICATION_DEFAULTS
+#            attachments:
+#              - color: "danger"
+#                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/cloud-platform-live-0/main/smoke-tests.yaml
+++ b/pipelines/cloud-platform-live-0/main/smoke-tests.yaml
@@ -12,7 +12,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-smoke-tests.git
-    branch: feature/concourse
+    branch: master
 - name: tools-image
   type: docker-image
   source:

--- a/pipelines/cloud-platform-live-0/main/smoke-tests.yaml
+++ b/pipelines/cloud-platform-live-0/main/smoke-tests.yaml
@@ -20,21 +20,21 @@ resources:
     tag: latest
     aws_access_key_id: ((aws.access-key-id))
     aws_secret_access_key: ((aws.secret-access-key))
-#- name: slack-alert
-#  type: slack-notification
-#  source:
-#    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
 - name: every-1hr
   type: time
   source:
     interval: 1h
 
-#resource_types:
-#- name: slack-notification
-#  type: docker-image
-#  source:
-#    repository: cfcommunity/slack-notification-resource
-#    tag: latest
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
 
 jobs:
   - name: smoke
@@ -63,13 +63,12 @@ jobs:
               - -c
               - |
                 aws s3 cp s3://cloud-platform-concourse-build-environments/kubeconfig /tmp/kubeconfig
-                ./tests/00-namespace-test/test.sh
-                ./tests/01-ingress-http-traffic/test.sh
-                ./tests/02-log-collection/test.sh
-#        on_failure:
-#          put: slack-alert
-#          params:
-#            <<: *SLACK_NOTIFICATION_DEFAULTS
-#            attachments:
-#              - color: "danger"
-#                <<: *SLACK_ATTACHMENTS_DEFAULTS
+                kubectl config use-context cloud-platform-live-0.k8s.integration.dsd.io
+                ./tests/resources/apply.sh
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform-smoke-tests/pull/5. It will create a smoke-test pipeline for the live-0 cluster, running once every hour. 

**What does this PR do?**
---
1. Creates a smoke-test pipeline on live-0.

**Why?**
---
1. To allow us to test the clusters health on a regular basis. 
