### PR TITLE
Export branch and master Shas for plan pipe line to pick

### DIFF
--- a/pipelines/cloud-platform-live-0/main/plan-environments.yaml
+++ b/pipelines/cloud-platform-live-0/main/plan-environments.yaml
@@ -48,6 +48,8 @@ jobs:
             args:
               - -c
               - |
+                export branch_head_sha=`cat .git/resource/metadata.json | jq -r '.[3] | .value'`
+                export master_base_sha=`cat .git/resource/metadata.json | jq -r '.[5] | .value'`
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 aws s3 cp s3://cloud-platform-concourse-build-environments/kubeconfig /tmp/kubeconfig
                 ./bin/plan


### PR DESCRIPTION
Export branch and master Shas as plan pipeline couldn't get branch details, so using git diff with the shas will pick up all commits while running plan pipeline when a PR is raised on cloud-platform -environments.