### PR TITLE
Update terraform backend locations

### DIFF
--- a/pipelines/live-1/main/build-environments/main.tf
+++ b/pipelines/live-1/main/build-environments/main.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket = "cloud-platform-terraform-state"
     region = "eu-west-1"
-    key    = "concourse-terraform/pipelines/live-1/main/build-environments/terraform.tfstate"
+    key    = "concourse-pipelines/live-1/main/build-environments/terraform.tfstate"
   }
 }
 

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -3,7 +3,7 @@ terraform {
     bucket               = "cloud-platform-terraform-state"
     region               = "eu-west-1"
     key                  = "terraform.tfstate"
-    workspace_key_prefix = "concourse-terraform"
+    workspace_key_prefix = "cloud-platform-concourse"
   }
 }
 


### PR DESCRIPTION
This is a small re-organisation of terraform states:

- concourse workspaces under `<bucket>/cloud-platform-concourse/`
- concourse pipeline resources under `<bucket>/concourse-pipelines/`

This change keeps the two of them separate to avoid any future conflicts.