### PR TITLE
Build and push the tools image in cloud-platform

### DIFF
--- a/pipelines/live-1/main/tools-image.yaml
+++ b/pipelines/live-1/main/tools-image.yaml
@@ -4,14 +4,14 @@ resources:
   source:
     branch: master
     uri: https://github.com/ministryofjustice/cloud-platform-tools-image
-- name: image-base
+- name: image-base-pi
   type: docker-image
   source:
     repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
     tag: latest
     aws_access_key_id: ((aws-live-0.access-key-id))
     aws_secret_access_key: ((aws-live-0.secret-access-key))
-- name: image-circleci
+- name: image-circleci-pi
   type: docker-image
   source:
     repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
@@ -26,9 +26,9 @@ jobs:
       - aggregate:
         - get: repo
           trigger: true
-        - get: image-base
+        - get: image-base-pi
       - task: ensure-repository-exists
-        image: image-base
+        image: image-base-pi
         config:
           platform: linux
           params:
@@ -61,7 +61,7 @@ jobs:
                       }
                     ]}'
       - task: prepare-image-tags
-        image: image-base
+        image: image-base-pi
         config:
           platform: linux
           inputs:
@@ -78,7 +78,7 @@ jobs:
                 echo "$(cat repo/.git/ref)" > build-repo/.git/ref
                 echo "$(cat repo/.git/ref)-circleci" > build-repo/.git/ref.circleci
                 (set -x; cat build-repo/.git/ref; cat build-repo/.git/ref.circleci)
-      - put: image-base
+      - put: image-base-pi
         params:
           build: build-repo
           dockerfile: build-repo/Dockerfile
@@ -86,7 +86,7 @@ jobs:
           tag_as_latest: false
           get_params:
             skip_download: true
-      - put: image-circleci
+      - put: image-circleci-pi
         params:
           build: build-repo
           dockerfile: build-repo/Dockerfile.circleci

--- a/pipelines/live-1/main/tools-image.yaml
+++ b/pipelines/live-1/main/tools-image.yaml
@@ -19,6 +19,57 @@ resources:
     aws_access_key_id: ((aws-live-0.access-key-id))
     aws_secret_access_key: ((aws-live-0.secret-access-key))
 
+ensure-repository-exists: &ensure-repository-exists-config
+  platform: linux
+  run:
+    path: /bin/sh
+    args:
+      - -c
+      - |
+        aws ecr create-repository \
+          --repository-name cloud-platform/tools || echo "error ignored"
+        aws ecr put-lifecycle-policy \
+          --repository-name cloud-platform/tools \
+          --lifecycle-policy-text '{
+            "rules": [
+              {
+                "rulePriority": 10,
+                "description": "remove-untagged",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 1
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]}'
+
+prepare-image-tags: &prepare-image-tags-config
+  platform: linux
+  inputs:
+    - name: repo
+  outputs:
+    - name: build-repo
+  run:
+    path: /bin/sh
+    args:
+      - -c
+      - |
+        git clone repo build-repo
+        # https://github.com/concourse/git-resource#additional-files-populated
+        echo "$(cat repo/.git/ref)" > build-repo/.git/ref
+        echo "$(cat repo/.git/ref)-circleci" > build-repo/.git/ref.circleci
+        (set -x; cat build-repo/.git/ref; cat build-repo/.git/ref.circleci)
+
+push-image: &push-image-params
+  build: build-repo
+  tag_as_latest: false
+  get_params:
+    skip_download: true
+
 jobs:
   - name: build
     serial: true
@@ -30,67 +81,24 @@ jobs:
       - task: ensure-repository-exists
         image: image-base-pi
         config:
-          platform: linux
           params:
             AWS_DEFAULT_REGION: eu-west-1
             AWS_ACCESS_KEY_ID: ((aws-live-0.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws-live-0.secret-access-key))
-          run:
-            path: /bin/sh
-            args:
-              - -c
-              - |
-                aws ecr create-repository \
-                  --repository-name cloud-platform/tools || echo "error ignored"
-                aws ecr put-lifecycle-policy \
-                  --repository-name cloud-platform/tools \
-                  --lifecycle-policy-text '{
-                    "rules": [
-                      {
-                        "rulePriority": 10,
-                        "description": "remove-untagged",
-                        "selection": {
-                          "tagStatus": "untagged",
-                          "countType": "sinceImagePushed",
-                          "countUnit": "days",
-                          "countNumber": 1
-                        },
-                        "action": {
-                          "type": "expire"
-                        }
-                      }
-                    ]}'
+          <<: *ensure-repository-exists-config
+
       - task: prepare-image-tags
         image: image-base-pi
         config:
-          platform: linux
-          inputs:
-            - name: repo
-          outputs:
-            - name: build-repo
-          run:
-            path: /bin/sh
-            args:
-              - -c
-              - |
-                git clone repo build-repo
-                # https://github.com/concourse/git-resource#additional-files-populated
-                echo "$(cat repo/.git/ref)" > build-repo/.git/ref
-                echo "$(cat repo/.git/ref)-circleci" > build-repo/.git/ref.circleci
-                (set -x; cat build-repo/.git/ref; cat build-repo/.git/ref.circleci)
+          <<: *prepare-image-tags-config
+
       - put: image-base-pi
         params:
-          build: build-repo
           dockerfile: build-repo/Dockerfile
           additional_tags: build-repo/.git/ref
-          tag_as_latest: false
-          get_params:
-            skip_download: true
+          <<: *push-image-params
       - put: image-circleci-pi
         params:
-          build: build-repo
           dockerfile: build-repo/Dockerfile.circleci
           additional_tags: build-repo/.git/ref.circleci
-          tag_as_latest: false
-          get_params:
-            skip_download: true
+          <<: *push-image-params

--- a/pipelines/live-1/main/tools-image.yaml
+++ b/pipelines/live-1/main/tools-image.yaml
@@ -18,6 +18,20 @@ resources:
     tag: circleci
     aws_access_key_id: ((aws-live-0.access-key-id))
     aws_secret_access_key: ((aws-live-0.secret-access-key))
+- name: image-base-cp
+  type: docker-image
+  source:
+    repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
+    tag: latest
+    aws_access_key_id: ((aws-live-1.access-key-id))
+    aws_secret_access_key: ((aws-live-1.secret-access-key))
+- name: image-circleci-cp
+  type: docker-image
+  source:
+    repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
+    tag: circleci
+    aws_access_key_id: ((aws-live-1.access-key-id))
+    aws_secret_access_key: ((aws-live-1.secret-access-key))
 
 ensure-repository-exists: &ensure-repository-exists-config
   platform: linux
@@ -70,8 +84,14 @@ push-image: &push-image-params
   get_params:
     skip_download: true
 
+groups:
+- name: pi
+  jobs: [build-pi]
+- name: cp
+  jobs: [build-cp]
+
 jobs:
-  - name: build
+  - name: build-pi
     serial: true
     plan:
       - aggregate:
@@ -86,18 +106,46 @@ jobs:
             AWS_ACCESS_KEY_ID: ((aws-live-0.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws-live-0.secret-access-key))
           <<: *ensure-repository-exists-config
-
       - task: prepare-image-tags
         image: image-base-pi
         config:
           <<: *prepare-image-tags-config
-
       - put: image-base-pi
         params:
           dockerfile: build-repo/Dockerfile
           additional_tags: build-repo/.git/ref
           <<: *push-image-params
       - put: image-circleci-pi
+        params:
+          dockerfile: build-repo/Dockerfile.circleci
+          additional_tags: build-repo/.git/ref.circleci
+          <<: *push-image-params
+
+  - name: build-cp
+    serial: true
+    plan:
+      - aggregate:
+        - get: repo
+          trigger: true
+        - get: image-base-pi
+      - task: ensure-repository-exists
+        image: image-base-pi
+        config:
+          params:
+            AWS_DEFAULT_REGION: eu-west-2
+            AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+          <<: *ensure-repository-exists-config
+      - task: prepare-image-tags
+        image: image-base-pi
+        config:
+          <<: *prepare-image-tags-config
+      - put: image-base-cp
+        params:
+          dockerfile: build-repo/Dockerfile
+          additional_tags: build-repo/.git/ref
+          <<: *push-image-params
+      - put: image-circleci-cp
         params:
           dockerfile: build-repo/Dockerfile.circleci
           additional_tags: build-repo/.git/ref.circleci


### PR DESCRIPTION
Since docker images are defined as resources, we need to define them twice and build twice.

Connects to https://github.com/ministryofjustice/cloud-platform/issues/771