### PR TITLE
Add Pingdom vars to plan pipeline

### DIFF
--- a/pipelines/live-1/main/plan-environments.yaml
+++ b/pipelines/live-1/main/plan-environments.yaml
@@ -50,6 +50,9 @@ jobs:
             KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
             KUBECONFIG: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
+            PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
+            PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
             # the variables prefixed with PIPELINE_ are used by the plan script
             PIPELINE_CLUSTER: cloud-platform-live-0.k8s.integration.dsd.io
             PIPELINE_STATE_BUCKET: moj-cp-k8s-investigation-environments-terraform
@@ -107,6 +110,9 @@ jobs:
             KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
             KUBECONFIG: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
+            PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
+            PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
             # the variables prefixed with PIPELINE_ are used by the plan script
             PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state


### PR DESCRIPTION
It was previously anticipated the plan pipeline had no need to authenticate to Pingdom. This is not the case as it first lists all current checks.