### PR TITLE
IAM role adjusted to allow management of Route53 zones

### DIFF
--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -149,13 +149,13 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
 
-  statement { 
+  statement {
     actions = [
-      "route53:ChangeResourceRecordSets"
+      "route53:CreateHostedZone",
     ]
-    
-    resources = [  
-       "arn:aws:route53:::hostedzone/*"
+
+    resources = [
+       "*",
     ]
   }
 
@@ -165,21 +165,24 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "arn:aws:route53:::change/*",
+       "arn:aws:route53:::change/*",
     ]
   }
-  
+
   statement {
     actions = [
-      "route53:ListHostedZonesByName",
+      "route53:GetHostedZone",
+      "route53:ListTagsForResource",
+      "route53:ChangeTagsForResource",
+      "route53:DeleteHostedZone",
     ]
 
     resources = [
-      "*",
+       "arn:aws:route53:::hostedzone/*",
     ]
   }
 }
-
+  
 resource "aws_iam_policy" "policy" {
   name        = "${terraform.workspace}-concourse-user-policy"
   path        = "/cloud-platform/"

--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -149,13 +149,14 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
 
+  # Roles to Create/Edit/Delete Route53 Zone.
   statement {
     actions = [
       "route53:CreateHostedZone",
     ]
 
     resources = [
-       "*",
+      "*",
     ]
   }
 
@@ -165,7 +166,7 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-       "arn:aws:route53:::change/*",
+      "arn:aws:route53:::change/*",
     ]
   }
 
@@ -178,11 +179,11 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-       "arn:aws:route53:::hostedzone/*",
+      "arn:aws:route53:::hostedzone/*",
     ]
   }
 }
-  
+
 resource "aws_iam_policy" "policy" {
   name        = "${terraform.workspace}-concourse-user-policy"
   path        = "/cloud-platform/"

--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -148,6 +148,36 @@ data "aws_iam_policy_document" "policy" {
       "*",
     ]
   }
+
+  statement { 
+    actions = [
+      "route53:ChangeResourceRecordSets"
+    ]
+    
+    resources = [  
+       "arn:aws:route53:::hostedzone/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "route53:GetChange",
+    ]
+
+    resources = [
+      "arn:aws:route53:::change/*",
+    ]
+  }
+  
+  statement {
+    actions = [
+      "route53:ListHostedZonesByName",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "policy" {


### PR DESCRIPTION
Concourse IAM role is adjusted to allow management of Route53 zones.

This is related to #835