### PR TITLE
Correct Slack channel name

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -1,5 +1,5 @@
 slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
-  channel: '#cp-build-notifications'
+  channel: '#cloud-platform-notify'
   silent: true
 slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
   fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'


### PR DESCRIPTION
We recently had a slack channel name change. This PR allows notifications to continue.