### PR TITLE
Bump orphaned namespace checker version to 2.10

### DIFF
--- a/pipelines/live-1/main/check-environment.yaml
+++ b/pipelines/live-1/main/check-environment.yaml
@@ -11,7 +11,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: 2.9
+    tag: 2.10
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/live-1/main/check-environment.yaml
+++ b/pipelines/live-1/main/check-environment.yaml
@@ -11,7 +11,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: 2.8
+    tag: 2.9
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
This version has this [bugfix commit](https://github.com/ministryofjustice/cloud-platform-environments-checker/commit/3bc76373b4c515ceed1c3432cd3068591d574f32)

When merged, this PR will cause the pipeline to use an updated version of the "orphaned namespace checker" docker image, to report on leftover cluster namespaces and their AWS resources.