### PR TITLE
Add integration tests for live-1

### DIFF
--- a/pipelines/live-1/main/integration-tests.yaml
+++ b/pipelines/live-1/main/integration-tests.yaml
@@ -1,0 +1,82 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#cloud-platform-notify'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: master
+- name: integration-test-image
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
+    tag: 1.2
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-hour
+  type: time
+  source:
+    interval: 1h
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+groups:
+- name: live-1
+  jobs: [apply-tests-live-1]
+
+jobs:
+- name: apply-tests-live-1
+  serial: true
+  plan:
+    - aggregate:
+      - get: every-hour
+        trigger: true
+      - get: integration-test-image
+        trigger: false
+      - get: cloud-platform-infrastructure-repo
+        trigger: false
+    - task: test-live-1
+      image: integration-test-image
+      config:
+        platform: linux
+        inputs:
+          - name: cloud-platform-infrastructure-repo
+        params:
+          AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+          AWS_REGION: eu-west-2
+          KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+          KUBECONFIG_S3_KEY: kubeconfig
+          KUBECONFIG: /tmp/kubeconfig
+          KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+        run:
+          path: /bin/sh
+          dir: cloud-platform-infrastructure-repo
+          args:
+            - -c
+            - |
+              aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+              kubectl config use-context ${KUBE_CLUSTER}
+              cd ./smoke-tests; rspec --tag cluster:live-1
+        outputs:
+          - name: metadata
+      on_failure:
+        put: slack-alert
+        params:
+          <<: *SLACK_NOTIFICATION_DEFAULTS
+          attachments:
+            - color: "danger"
+              <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/1117 and relates to the creation of an integration test in live-1. 

**What does it do?**
---
This pipeline uses the [smoke-test image] (https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/smoke-tests/Dockerfile) to run the master branch integration tests against the live-1 cluster. 

This first requires us to authenticate against the cluster using the assigned kubeconfig file, then changes directory and executes the rspec command. 

This allows us to run all live-1 tests without rebuilding the image. 