### PR TITLE
Change integration rspec tags

### DIFF
--- a/pipelines/live-1/main/integration-tests.yaml
+++ b/pipelines/live-1/main/integration-tests.yaml
@@ -70,7 +70,7 @@ jobs:
             - |
               aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
               kubectl config use-context ${KUBE_CLUSTER}
-              cd ./smoke-tests; rspec --tag cluster:live-1
+              cd ./smoke-tests; rspec 
         outputs:
           - name: metadata
       on_failure:


### PR DESCRIPTION
This change will run ALL tests against the live cluster. The live-1 tag should be used to stop rspec running certain tests against non-live clusters not the other way around.