### PR TITLE
Use 'latest' smoke-test docker image

### DIFF
--- a/pipelines/live-1/main/integration-tests.yaml
+++ b/pipelines/live-1/main/integration-tests.yaml
@@ -16,7 +16,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
-    tag: 1.2
+    tag: latest
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/live-1/main/integration-tests.yaml
+++ b/pipelines/live-1/main/integration-tests.yaml
@@ -70,7 +70,7 @@ jobs:
             - |
               aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
               kubectl config use-context ${KUBE_CLUSTER}
-              cd ./smoke-tests; rspec 
+              cd ./smoke-tests; rspec
         outputs:
           - name: metadata
       on_failure:


### PR DESCRIPTION
This way, if we add gems to the test image, the test pipeline will not need
to be changed