### PR TITLE
Replace ECR tools image with tagged Dockerhub image

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -17,10 +17,8 @@ resources:
 - name: tools-image
   type: docker-image
   source:
-    repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
-    tag: latest
-    aws_access_key_id: ((aws-live-0.access-key-id))
-    aws_secret_access_key: ((aws-live-0.secret-access-key))
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
+    tag: 1.0 
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/live-1/main/plan-environments.yaml
+++ b/pipelines/live-1/main/plan-environments.yaml
@@ -24,10 +24,8 @@ resources:
 - name: tools-image
   type: docker-image
   source:
-    repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
-    tag: latest
-    aws_access_key_id: ((aws-live-0.access-key-id))
-    aws_secret_access_key: ((aws-live-0.secret-access-key))
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
+    tag: 1.0 
 
 groups:
 - name: live-0

--- a/pipelines/live-1/main/tools-image.yaml
+++ b/pipelines/live-1/main/tools-image.yaml
@@ -7,10 +7,8 @@ resources:
 - name: image-base-pi
   type: docker-image
   source:
-    repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
-    tag: latest
-    aws_access_key_id: ((aws-live-0.access-key-id))
-    aws_secret_access_key: ((aws-live-0.secret-access-key))
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
+    tag: 1.0 
 - name: image-circleci-pi
   type: docker-image
   source:
@@ -21,10 +19,8 @@ resources:
 - name: image-base-cp
   type: docker-image
   source:
-    repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
-    tag: latest
-    aws_access_key_id: ((aws-live-1.access-key-id))
-    aws_secret_access_key: ((aws-live-1.secret-access-key))
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
+    tag: 1.0 
 - name: image-circleci-cp
   type: docker-image
   source:


### PR DESCRIPTION
**Overview**
---
This PR will replace the older Docker image from ECR with the new image placed in Dockerhub
https://cloud.docker.com/u/ministryofjustice/repository/docker/ministryofjustice/cloud-platform-tools