### PR TITLE
Reduce container requests to actual usage values

### DIFF
--- a/resources/templates/values.yaml
+++ b/resources/templates/values.yaml
@@ -1119,8 +1119,8 @@ web:
   ##
   resources:
     requests:
-      cpu: "100m"
-      memory: "250Mi"
+      cpu: "20m"
+      memory: "100Mi"
     limits:
       cpu: "100m"
       memory: "250Mi"
@@ -1362,8 +1362,8 @@ worker:
   ##
   resources:
     requests:
-      cpu: "1000m"
-      memory: "4Gi"
+      cpu: "50m"
+      memory: "1Gi"
     limits:
       cpu: "1000m"
       memory: "4Gi"


### PR DESCRIPTION
The concourse worker containers resource usage
looks like this;

      used (cpu, memory): 53        1279
      used (cpu, memory): 463       1043

The web container looks like this;

      used (cpu, memory): 19        73

This commit brings the concourse container
resource requests down to values which are close
to what is actually used.

After this PR is merged, it needs to be redeployed
via `terraform apply`