### PR TITLE
Use the 1.4-test tag of the tools image

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.3
+    tag: 1.4-test
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/live-1/main/plan-environments.yaml
+++ b/pipelines/live-1/main/plan-environments.yaml
@@ -25,7 +25,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.1
+    tag: 1.4-test
 
 groups:
 - name: live-0

--- a/pipelines/live-1/main/tools-image.yaml
+++ b/pipelines/live-1/main/tools-image.yaml
@@ -8,7 +8,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.3
+    tag: 1.4-test
 - name: image-circleci-pi
   type: docker-image
   source:
@@ -20,7 +20,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.3
+    tag: 1.4-test
 - name: image-circleci-cp
   type: docker-image
   source:


### PR DESCRIPTION
The only difference between 1.3 and 1.4-test is
the use of CMD instead of ENTRYPOINT

This change will let us see if making that change
to the tools image (which is useful for github
actions) will cause any problems in the concourse
pipelines