### PR TITLE
Tag the tools image as 1.4

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.4-test
+    tag: 1.4
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/live-1/main/plan-environments.yaml
+++ b/pipelines/live-1/main/plan-environments.yaml
@@ -25,7 +25,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.4-test
+    tag: 1.4
 
 groups:
 - name: live-0

--- a/pipelines/live-1/main/tools-image.yaml
+++ b/pipelines/live-1/main/tools-image.yaml
@@ -8,7 +8,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.4-test
+    tag: 1.4
     username: ((cloud-platform-environments-dockerhub.dockerhub_username))
     password: ((cloud-platform-environments-dockerhub.dockerhub_access_token))
 
@@ -23,7 +23,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.4-test
+    tag: 1.4
     username: ((cloud-platform-environments-dockerhub.dockerhub_username))
     password: ((cloud-platform-environments-dockerhub.dockerhub_access_token))
 


### PR DESCRIPTION
We were using 1.4-test to see if changing the image to CMD from
ENTRYPOINT caused any problems. It doesn't seem as if it does, so
we can now build and use 1.4 everywhere.

I've manually built and pushed the 1.4 tag to docker hub already,
so it should be fine to specify 1.4 in the plan and build
pipelines now, rather than having separate PRs for tagging the
image and using the image.