### PR TITLE
Create a DynamoDB table for tf state locking

### DIFF
--- a/pipelines/live-1/main/build-environments/dynamodb.tf
+++ b/pipelines/live-1/main/build-environments/dynamodb.tf
@@ -1,0 +1,22 @@
+// Create a DynamoDB table so we can lock the terraform state of each
+// namespace in the cloud-platform-environments repository, as we
+// `terraform apply` it.
+//
+// This table name is referenced from the environments repo, so that
+// terraform can use it to lock the state of each namespace.
+
+resource "aws_dynamodb_table" "cloud-platform-environments-terraform-lock" {
+  name = "cloud-platform-environments-terraform-lock"
+  hash_key = "LockID"
+  read_capacity = 20
+  write_capacity = 20
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags {
+    Name = "Terraform Lock Table for namespaces in the cloud-platform-environments repository"
+  }
+}


### PR DESCRIPTION
This just creates the table. The code to actually use it will live
in the environments repo, in the namespace folders.

This commit has to be merged to master before I can start
working on the terraform states in the environments repo,
because the bootstrap pipeline reapplies this terraform
state periodically, so it will delete the dynamodb table
if it's not part of the mater branch.