### PR TITLE
Create the dynamodb table in eu-west-1

### DIFF
--- a/pipelines/live-1/main/build-environments/dynamodb.tf
+++ b/pipelines/live-1/main/build-environments/dynamodb.tf
@@ -11,6 +11,8 @@ resource "aws_dynamodb_table" "cloud-platform-environments-terraform-lock" {
   read_capacity = 20
   write_capacity = 20
 
+  provider = "aws.ireland"
+
   attribute {
     name = "LockID"
     type = "S"

--- a/pipelines/live-1/main/build-environments/main.tf
+++ b/pipelines/live-1/main/build-environments/main.tf
@@ -9,3 +9,8 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}


### PR DESCRIPTION
The dynamodb table must be in the same region as
the s3 bucket in which the terraform state lives.

This commit creates a dynamodb table in eu-west-1

I'll delete the existing table in eu-west-2 
manually.