### PR TITLE
Add state-locking dynamodb table name as env. var.

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -127,6 +127,7 @@ jobs:
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_CLUSTER_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_CLUSTER_STATE_KEY_PREFIX: "cloud-platform/"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-repo


### PR DESCRIPTION
This commit makes available the name of the
dynamodb table that the pipeline should use to
lock the terraform state of each environment, as 
it updates them.

This commit depends on #111, which created the
DynamoDB table.