### PR TITLE
Set dynamodb table name in live-0 pipeline

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -74,6 +74,7 @@ jobs:
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_CLUSTER_STATE_BUCKET: moj-cp-k8s-investigation-platform-terraform
             PIPELINE_CLUSTER_STATE_KEY_PREFIX: "env:/"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-repo


### PR DESCRIPTION
This commit fixes the live-0 build pipeline, which is failing
because the apply script in the environments repo. is trying to
access the PIPELINE_TERRAFORM_STATE_LOCK_TABLE environment variable
(which isn't set until this commit is merged).