### PR TITLE
Add the dynamodb lock table to the plan pipeline

### DIFF
--- a/pipelines/live-1/main/plan-environments.yaml
+++ b/pipelines/live-1/main/plan-environments.yaml
@@ -68,6 +68,7 @@ jobs:
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_CLUSTER_STATE_BUCKET: moj-cp-k8s-investigation-platform-terraform
             PIPELINE_CLUSTER_STATE_KEY_PREFIX: "env:/"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-live-0-pull-requests
@@ -128,6 +129,7 @@ jobs:
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_CLUSTER_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_CLUSTER_STATE_KEY_PREFIX: "cloud-platform/"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-live-1-pull-requests


### PR DESCRIPTION
`terraform plan` briefly locks the terraform state, if locking is
enabled. This commit sets the dynamodb lock table name as an
environment variable for the plan pipeline, in the same way as we
do for the build pipeline.