### PR TITLE
Namespace changes build

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -49,7 +49,7 @@ jobs:
         - get: every-30m
           trigger: true
         - get: cloud-platform-environments-repo
-          trigger: true
+          trigger: false
         - get: tools-image
       - task: apply-environments
         image: tools-image
@@ -103,7 +103,7 @@ jobs:
         - get: every-30m
           trigger: true
         - get: cloud-platform-environments-repo
-          trigger: true
+          trigger: false
         - get: tools-image
       - task: apply-environments
         image: tools-image

--- a/pipelines/live-1/main/build-namespace-changes.yaml
+++ b/pipelines/live-1/main/build-namespace-changes.yaml
@@ -1,0 +1,143 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+  silent: true
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: master
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.4
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+groups:
+- name: live-0
+  jobs: [apply-namespace-changes-live-0]
+- name: live-1
+  jobs: [apply-namespace-changes-live-1]
+
+jobs:
+  - name: apply-namespace-changes-live-0
+    serial: true
+    plan:
+      - aggregate:
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: tools-image
+      - task: apply-namespace-changes
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-live-0.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-0.secret-access-key))
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
+            PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
+            PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
+            # the variables prefixed with PIPELINE_ are used by the apply script
+            PIPELINE_CLUSTER: cloud-platform-live-0.k8s.integration.dsd.io
+            PIPELINE_STATE_BUCKET: moj-cp-k8s-investigation-environments-terraform
+            PIPELINE_STATE_KEY_PREFIX: ""
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_CLUSTER_STATE_BUCKET: moj-cp-k8s-investigation-platform-terraform
+            PIPELINE_CLUSTER_STATE_KEY_PREFIX: "env:/"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  AWS_ACCESS_KEY_ID="${KUBECONFIG_AWS_ACCESS_KEY_ID}"
+                  AWS_SECRET_ACCESS_KEY="${KUBECONFIG_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                ./bin/apply-namespace-changes
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: apply-namespace-changes-live-1
+    serial: true
+    plan:
+      - aggregate:
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: tools-image
+      - task: apply-namespace-changes
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
+            PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
+            PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
+            # the variables prefixed with PIPELINE_ are used by the apply script
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_CLUSTER_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_CLUSTER_STATE_KEY_PREFIX: "cloud-platform/"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  AWS_ACCESS_KEY_ID="${KUBECONFIG_AWS_ACCESS_KEY_ID}"
+                  AWS_SECRET_ACCESS_KEY="${KUBECONFIG_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                ./bin/apply-namespace-changes
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
This is related to https://github.com/ministryofjustice/cloud-platform/issues/1115

This Change will set build-environments pipeline to run only on schedule but not trigger on merge
Also create a new pipeline build-namespace-changes which will run on PR merge and run a script (./bin/apply-namespace-changes) in environments repo. 

`apply-namespace-changes` will get the namespace list changed in the PR and run apply for K8 and Terraform resources.