### PR TITLE
Tf12 upgrade of the concourse resources

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -15,7 +15,7 @@ provider "aws" {
 data "terraform_remote_state" "cluster" {
   backend = "s3"
 
-  config {
+  config = {
     bucket = "cloud-platform-terraform-state"
     region = "eu-west-1"
     key    = "cloud-platform/live-1/terraform.tfstate"
@@ -30,13 +30,21 @@ data "terraform_remote_state" "cluster" {
 resource "aws_security_group" "concourse" {
   name        = "${terraform.workspace}-concourse"
   description = "Allow all inbound traffic from the VPC"
-  vpc_id      = "${data.terraform_remote_state.cluster.vpc_id}"
+  vpc_id      = data.terraform_remote_state.cluster.outputs.vpc_id
 
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["${data.terraform_remote_state.cluster.internal_subnets}"]
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+    # force an interpolation expression to be interpreted as a list by wrapping it
+    # in an extra set of list brackets. That form was supported for compatibility in
+    # v0.11, but is no longer supported in Terraform v0.12.
+    #
+    # If the expression in the following list itself returns a list, remove the
+    # brackets to avoid interpretation as a list of lists. If the expression
+    # returns a single list item then leave it as-is and remove this TODO comment.
+    cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 
   egress {
@@ -46,7 +54,7 @@ resource "aws_security_group" "concourse" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${terraform.workspace}-concourse"
   }
 }
@@ -54,7 +62,15 @@ resource "aws_security_group" "concourse" {
 resource "aws_db_subnet_group" "concourse" {
   name        = "${terraform.workspace}-concourse"
   description = "Internal subnet groups"
-  subnet_ids  = ["${data.terraform_remote_state.cluster.internal_subnets_ids}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  subnet_ids = data.terraform_remote_state.cluster.outputs.internal_subnets_ids
 }
 
 resource "random_string" "db_password" {
@@ -63,17 +79,17 @@ resource "random_string" "db_password" {
 }
 
 resource "aws_db_instance" "concourse" {
-  depends_on             = ["aws_security_group.concourse"]
+  depends_on             = [aws_security_group.concourse]
   identifier             = "${terraform.workspace}-concourse"
-  allocated_storage      = "${var.rds_storage}"
+  allocated_storage      = var.rds_storage
   engine                 = "postgres"
-  engine_version         = "${var.rds_postgresql_version}"
-  instance_class         = "${var.rds_instance_class}"
+  engine_version         = var.rds_postgresql_version
+  instance_class         = var.rds_instance_class
   name                   = "concourse"
   username               = "concourse"
-  password               = "${random_string.db_password.result}"
-  vpc_security_group_ids = ["${aws_security_group.concourse.id}"]
-  db_subnet_group_name   = "${aws_db_subnet_group.concourse.id}"
+  password               = random_string.db_password.result
+  vpc_security_group_ids = [aws_security_group.concourse.id]
+  db_subnet_group_name   = aws_db_subnet_group.concourse.id
   skip_final_snapshot    = true
 }
 
@@ -108,78 +124,96 @@ resource "random_string" "basic_auth_password" {
 }
 
 data "template_file" "values" {
-  template = "${file("${path.module}/templates/values.yaml")}"
+  template = file("${path.module}/templates/values.yaml")
 
-  vars {
-    concourse_image_tag       = "${var.concourse_image_tag}"
-    basic_auth_username       = "${random_string.basic_auth_username.result}"
-    basic_auth_password       = "${random_string.basic_auth_password.result}"
-    github_auth_client_id     = "${local.secrets["github_auth_client_id"]}"
-    github_auth_client_secret = "${local.secrets["github_auth_client_secret"]}"
-    concourse_hostname        = "${terraform.workspace == local.live_workspace ? format("%s.%s", "concourse", local.live_domain) : format("%s.%s", "concourse.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
-    github_org                = "${local.secrets["github_org"]}"
-    github_teams              = "${local.secrets["github_teams"]}"
-    postgresql_user           = "${aws_db_instance.concourse.username}"
-    postgresql_password       = "${aws_db_instance.concourse.password}"
-    postgresql_host           = "${aws_db_instance.concourse.address}"
-    postgresql_sslmode        = false
-    host_key_priv             = "${indent(4, tls_private_key.host_key.private_key_pem)}"
-    host_key_pub              = "${tls_private_key.host_key.public_key_openssh}"
-    session_signing_key_priv  = "${indent(4, tls_private_key.session_signing_key.private_key_pem)}"
-    worker_key_priv           = "${indent(4, tls_private_key.worker_key.private_key_pem)}"
-    worker_key_pub            = "${tls_private_key.worker_key.public_key_openssh}"
+  vars = {
+    concourse_image_tag       = var.concourse_image_tag
+    basic_auth_username       = random_string.basic_auth_username.result
+    basic_auth_password       = random_string.basic_auth_password.result
+    github_auth_client_id     = local.secrets["github_auth_client_id"]
+    github_auth_client_secret = local.secrets["github_auth_client_secret"]
+    concourse_hostname = terraform.workspace == local.live_workspace ? format("%s.%s", "concourse", local.live_domain) : format(
+      "%s.%s",
+      "concourse.apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
+    github_org               = local.secrets["github_org"]
+    github_teams             = local.secrets["github_teams"]
+    postgresql_user          = aws_db_instance.concourse.username
+    postgresql_password      = aws_db_instance.concourse.password
+    postgresql_host          = aws_db_instance.concourse.address
+    postgresql_sslmode       = false
+    host_key_priv            = indent(4, tls_private_key.host_key.private_key_pem)
+    host_key_pub             = tls_private_key.host_key.public_key_openssh
+    session_signing_key_priv = indent(4, tls_private_key.session_signing_key.private_key_pem)
+    worker_key_priv          = indent(4, tls_private_key.worker_key.private_key_pem)
+    worker_key_pub           = tls_private_key.worker_key.public_key_openssh
   }
 }
 
 module "concourse_user_cp" {
-  source      = "concourse-aws-user"
+  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
+  # reference a relative module source without a preceding ./, but it is no
+  # longer supported in Terraform v0.12.
+  #
+  # If the below module source is indeed a relative local path, add ./ to the
+  # start of the source string. If that is not the case, then leave it as-is
+  # and remove this TODO comment.
+  source      = "./concourse-aws-user"
   aws_profile = "moj-cp"
 }
 
 resource "kubernetes_secret" "concourse_aws_credentials" {
-  depends_on = ["helm_release.concourse"]
+  depends_on = [helm_release.concourse]
 
   metadata {
     name      = "aws-${terraform.workspace}"
     namespace = "concourse-main"
   }
 
-  data {
-    access-key-id     = "${module.concourse_user_cp.id}"
-    secret-access-key = "${module.concourse_user_cp.secret}"
+  data = {
+    access-key-id     = module.concourse_user_cp.id
+    secret-access-key = module.concourse_user_cp.secret
   }
 }
 
 module "concourse_user_pi" {
-  source      = "concourse-aws-user"
+  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
+  # reference a relative module source without a preceding ./, but it is no
+  # longer supported in Terraform v0.12.
+  #
+  # If the below module source is indeed a relative local path, add ./ to the
+  # start of the source string. If that is not the case, then leave it as-is
+  # and remove this TODO comment.
+  source      = "./concourse-aws-user"
   aws_profile = "moj-pi"
 }
 
 resource "kubernetes_secret" "concourse_aws_credentials_pi" {
-  depends_on = ["helm_release.concourse"]
+  depends_on = [helm_release.concourse]
 
   metadata {
     name      = "aws-live-0"
     namespace = "concourse-main"
   }
 
-  data {
-    access-key-id     = "${module.concourse_user_pi.id}"
-    secret-access-key = "${module.concourse_user_pi.secret}"
+  data = {
+    access-key-id     = module.concourse_user_pi.id
+    secret-access-key = module.concourse_user_pi.secret
   }
 }
 
 resource "kubernetes_secret" "concourse_basic_auth_credentials" {
-  depends_on = ["helm_release.concourse"]
+  depends_on = [helm_release.concourse]
 
   metadata {
     name      = "concourse-basic-auth"
     namespace = "concourse-main"
   }
 
-  data {
-    username = "${random_string.basic_auth_username.result}"
-    password = "${random_string.basic_auth_password.result}"
+  data = {
+    username = random_string.basic_auth_username.result
+    password = random_string.basic_auth_password.result
   }
 }
 
@@ -188,15 +222,15 @@ resource "helm_release" "concourse" {
   namespace     = "concourse"
   repository    = "stable"
   chart         = "concourse"
-  version       = "${var.concourse_chart_version}"
+  version       = var.concourse_chart_version
   recreate_pods = true
 
   values = [
-    "${data.template_file.values.rendered}",
+    data.template_file.values.rendered,
   ]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
 
@@ -206,7 +240,7 @@ resource "kubernetes_config_map" "concourse_mainteam_config_map" {
     namespace = "concourse"
   }
 
-  data {
+  data = {
     "roles.yml" = <<ROLES
 roles:
 - name: owner
@@ -219,6 +253,7 @@ roles:
   github:
     orgs: [ "${local.secrets["github_org"]}" ]
 ROLES
+
   }
 }
 
@@ -229,3 +264,4 @@ locals {
 
   live_domain = "cloud-platform.service.justice.gov.uk"
 }
+

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -36,14 +36,6 @@ resource "aws_security_group" "concourse" {
     from_port = 0
     to_port   = 0
     protocol  = "-1"
-    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-    # force an interpolation expression to be interpreted as a list by wrapping it
-    # in an extra set of list brackets. That form was supported for compatibility in
-    # v0.11, but is no longer supported in Terraform v0.12.
-    #
-    # If the expression in the following list itself returns a list, remove the
-    # brackets to avoid interpretation as a list of lists. If the expression
-    # returns a single list item then leave it as-is and remove this TODO comment.
     cidr_blocks = data.terraform_remote_state.cluster.outputs.internal_subnets
   }
 
@@ -62,14 +54,6 @@ resource "aws_security_group" "concourse" {
 resource "aws_db_subnet_group" "concourse" {
   name        = "${terraform.workspace}-concourse"
   description = "Internal subnet groups"
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   subnet_ids = data.terraform_remote_state.cluster.outputs.internal_subnets_ids
 }
 
@@ -152,13 +136,6 @@ data "template_file" "values" {
 }
 
 module "concourse_user_cp" {
-  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
-  # reference a relative module source without a preceding ./, but it is no
-  # longer supported in Terraform v0.12.
-  #
-  # If the below module source is indeed a relative local path, add ./ to the
-  # start of the source string. If that is not the case, then leave it as-is
-  # and remove this TODO comment.
   source      = "./concourse-aws-user"
   aws_profile = "moj-cp"
 }
@@ -178,13 +155,6 @@ resource "kubernetes_secret" "concourse_aws_credentials" {
 }
 
 module "concourse_user_pi" {
-  # TF-UPGRADE-TODO: In Terraform v0.11 and earlier, it was possible to
-  # reference a relative module source without a preceding ./, but it is no
-  # longer supported in Terraform v0.12.
-  #
-  # If the below module source is indeed a relative local path, add ./ to the
-  # start of the source string. If that is not the case, then leave it as-is
-  # and remove this TODO comment.
   source      = "./concourse-aws-user"
   aws_profile = "moj-pi"
 }

--- a/resources/variables.tf
+++ b/resources/variables.tf
@@ -22,3 +22,4 @@ variable "concourse_chart_version" {
   default     = "5.0.0"
   description = "The Helm chart version"
 }
+

--- a/resources/versions.tf
+++ b/resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This PR introduces changes to make the Concourse pipeline Terraform v0.12 compliant.

The bulk of the changes are coming from the `terraform 0.12upgrade`. 
Terraform couldn't decide what to do in a few instances, so it was manually fixed. 

This is part of the terraform v0.11.14 to v0.12.13 upgrade.