### PR TITLE
Update environments checker docker image version

### DIFF
--- a/pipelines/live-1/main/check-environment.yaml
+++ b/pipelines/live-1/main/check-environment.yaml
@@ -11,7 +11,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: 2.12
+    tag: 2.13
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
The latest version is 2.13, which uses terraform
state locking via dynamodb.

depends on https://github.com/ministryofjustice/cloud-platform-environments-checker/pull/15