### PR TITLE
Use version 1.5 of the tools image

### DIFF
--- a/pipelines/live-1/main/bootstrap.yaml
+++ b/pipelines/live-1/main/bootstrap.yaml
@@ -12,7 +12,8 @@ resources:
 - name: tools-image
   type: docker-image
   source:
-    repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/tools
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.5
     aws_access_key_id: ((aws-live-0.access-key-id))
     aws_secret_access_key: ((aws-live-0.secret-access-key))
 

--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.4
+    tag: 1.5
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/live-1/main/build-namespace-changes.yaml
+++ b/pipelines/live-1/main/build-namespace-changes.yaml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.4
+    tag: 1.5
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/live-1/main/plan-environments.yaml
+++ b/pipelines/live-1/main/plan-environments.yaml
@@ -25,7 +25,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.4
+    tag: 1.5
 
 groups:
 - name: live-0

--- a/pipelines/live-1/main/tools-image.yaml
+++ b/pipelines/live-1/main/tools-image.yaml
@@ -8,7 +8,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.4
+    tag: 1.5
     username: ((cloud-platform-environments-dockerhub.dockerhub_username))
     password: ((cloud-platform-environments-dockerhub.dockerhub_access_token))
 
@@ -23,7 +23,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.4
+    tag: 1.5
     username: ((cloud-platform-environments-dockerhub.dockerhub_username))
     password: ((cloud-platform-environments-dockerhub.dockerhub_access_token))
 


### PR DESCRIPTION
depends on https://github.com/ministryofjustice/cloud-platform-tools-image/pull/44

This is the version which has a terraform12
executable, to enable us to do a staged upgrade of
the terraform code in the environments repo.