### PR TITLE
Tf12 upgrade of pipeline infrastructure

### DIFF
--- a/pipelines/live-1/main/build-environments/dynamodb.tf
+++ b/pipelines/live-1/main/build-environments/dynamodb.tf
@@ -6,19 +6,20 @@
 // terraform can use it to lock the state of each namespace.
 
 resource "aws_dynamodb_table" "cloud-platform-environments-terraform-lock" {
-  name = "cloud-platform-environments-terraform-lock"
-  hash_key = "LockID"
-  read_capacity = 20
+  name           = "cloud-platform-environments-terraform-lock"
+  hash_key       = "LockID"
+  read_capacity  = 20
   write_capacity = 20
 
-  provider = "aws.ireland"
+  provider = aws.ireland
 
   attribute {
     name = "LockID"
     type = "S"
   }
 
-  tags {
+  tags = {
     Name = "Terraform Lock Table for namespaces in the cloud-platform-environments repository"
   }
 }
+

--- a/pipelines/live-1/main/build-environments/kubeconfig.tf
+++ b/pipelines/live-1/main/build-environments/kubeconfig.tf
@@ -3,35 +3,35 @@ variable "clusters" {
 }
 
 data "template_file" "clusters" {
-  count = "${length(var.clusters)}"
+  count = length(var.clusters)
 
-  template = "${file("${path.module}/templates/cluster.tpl")}"
+  template = file("${path.module}/templates/cluster.tpl")
 
-  vars {
-    name    = "${lookup(var.clusters[count.index], "name")}"
-    host    = "${lookup(var.clusters[count.index], "host")}"
-    ca_data = "${lookup(var.clusters[count.index], "ca_data")}"
+  vars = {
+    name    = var.clusters[count.index]["name"]
+    host    = var.clusters[count.index]["host"]
+    ca_data = var.clusters[count.index]["ca_data"]
   }
 }
 
 data "template_file" "users" {
-  count = "${length(var.clusters)}"
+  count = length(var.clusters)
 
-  template = "${file("${path.module}/templates/user.tpl")}"
+  template = file("${path.module}/templates/user.tpl")
 
-  vars {
-    name  = "${lookup(var.clusters[count.index], "name")}"
-    token = "${lookup(var.clusters[count.index], "token")}"
+  vars = {
+    name  = var.clusters[count.index]["name"]
+    token = var.clusters[count.index]["token"]
   }
 }
 
 data "template_file" "contexts" {
-  count = "${length(var.clusters)}"
+  count = length(var.clusters)
 
-  template = "${file("${path.module}/templates/context.tpl")}"
+  template = file("${path.module}/templates/context.tpl")
 
-  vars {
-    name = "${lookup(var.clusters[count.index], "name")}"
+  vars = {
+    name = var.clusters[count.index]["name"]
   }
 }
 
@@ -54,7 +54,7 @@ resource "aws_s3_bucket" "kubeconfig" {
 
 resource "aws_s3_bucket_object" "kubeconfig" {
   key    = "kubeconfig"
-  bucket = "${aws_s3_bucket.kubeconfig.id}"
+  bucket = aws_s3_bucket.kubeconfig.id
 
   content = <<EOF
 apiVersion: v1
@@ -69,5 +69,7 @@ users:
 ${join("", data.template_file.users.*.rendered)}
 EOF
 
+
   server_side_encryption = "AES256"
 }
+

--- a/pipelines/live-1/main/build-environments/main.tf
+++ b/pipelines/live-1/main/build-environments/main.tf
@@ -14,3 +14,4 @@ provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"
 }
+

--- a/pipelines/live-1/main/build-environments/versions.tf
+++ b/pipelines/live-1/main/build-environments/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/pipelines/live-1/main/tzcronjobber/ecr.tf
+++ b/pipelines/live-1/main/tzcronjobber/ecr.tf
@@ -3,7 +3,7 @@ resource "aws_ecr_repository" "repo" {
 }
 
 resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
-  repository = "${aws_ecr_repository.repo.name}"
+  repository = aws_ecr_repository.repo.name
 
   policy = <<EOF
 {
@@ -23,4 +23,6 @@ resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
     ]
 }
 EOF
+
 }
+

--- a/pipelines/live-1/main/tzcronjobber/main.tf
+++ b/pipelines/live-1/main/tzcronjobber/main.tf
@@ -9,3 +9,4 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
 }
+

--- a/pipelines/live-1/main/tzcronjobber/versions.tf
+++ b/pipelines/live-1/main/tzcronjobber/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -5,7 +5,7 @@ terraform {
     key                  = "terraform.tfstate"
     workspace_key_prefix = "cloud-platform-concourse"
   }
-  required_version = "0.11.14"
+  required_version = "0.12.13"
 }
 
 provider "aws" {
@@ -19,7 +19,7 @@ data "terraform_remote_state" "cluster" {
   config = {
     bucket = "cloud-platform-terraform-state"
     region = "eu-west-1"
-    key    = "cloud-platform/dstest-2/terraform.tfstate"
+    key    = "cloud-platform/live-1/terraform.tfstate"
   }
 }
 

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -5,6 +5,7 @@ terraform {
     key                  = "terraform.tfstate"
     workspace_key_prefix = "cloud-platform-concourse"
   }
+  required_version = "0.11.14"
 }
 
 provider "aws" {
@@ -18,7 +19,7 @@ data "terraform_remote_state" "cluster" {
   config {
     bucket = "cloud-platform-terraform-state"
     region = "eu-west-1"
-    key    = "cloud-platform/live-1/terraform.tfstate"
+    key    = "cloud-platform/dstest-2/terraform.tfstate"
   }
 }
 


### PR DESCRIPTION
After having upgraded the concourse terraform config, this PR upgrades the infrastructure used by different pipelines : 

- The build-environment pipeline

- The Tzcronjober pipeline

Both `terraform plan` indicates no change have been introduced.
This should have no impact on the actual pipelines.