### PR TITLE
Use version 1.5 of the tools image

### DIFF
--- a/bin/force-pipeline-state
+++ b/bin/force-pipeline-state
@@ -27,8 +27,8 @@ _tf() {
   echo ">>> creating pipeline resources for $(basename ${2})"
   (
     set -x
-    terraform init
-    terraform "${1}" -auto-approve | sed -E 's/((content|template):[[:space:]]+)".+"/\1<REDACTED>/'
+    terraform12 init
+    terraform12 "${1}" -auto-approve | sed -E 's/((content|template):[[:space:]]+)".+"/\1<REDACTED>/'
   )
   cd $OLDPWD
 }


### PR DESCRIPTION
depends on https://github.com/ministryofjustice/cloud-platform-tools-image/pull/44

This is the version which has a terraform12
executable, to enable us to do a staged upgrade of
the terraform code in the environments repo.