### PR TITLE
Update the README to correct some out of date information

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ terraform select workspace default
 terraform workspace delete <cluster-name>
 ```
 
-The created namespaces are not deleted by `helm` but `terraform` *does* manage the two starting ones (`concourse` and `concourse-main`) and will delete them during `destroy`.
+3. Destroy the namespaces
+
+```
+kubectl delete namespace concourse-main
+kubectl delete namespace concourse
+```
 
 ## Pipelines
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ Or, if you have `kops` installed:
 
 3. Edit `resources/secrets.tf` and add a configuration block for the new cluster, if one does not already exist.
 
+4. Create namespaces:
 
-4. Run terraform to bootstraps a Concourse deployment on a Kubernetes cluster <cluster-name> using the Helm package manager.
-   
-   `terraform apply`
+* `kubectl create namespace concourse`
+* `kubectl create namespace concourse-main`
 
-Two namespaces are created: `concourse` and `concourse-main`. Please make sure you define them in the [environments repository](https://github.com/ministryofjustice/cloud-platform-environments).
+5. Run terraform to bootstraps a Concourse deployment on a Kubernetes cluster <cluster-name> using the Helm package manager.
 
-*NOTE*: Due to the way `helm` manages namespaces for concourse secrets (`concourse-main` in this case), it will fail on the first run of the setup script. If this occurs, with an error message complaining about the existence of the `concourse-main` namespace, please run it a second time.
+   `cd resources; terraform apply`
+
+Please make sure you define the namespaces `concourse` and `concourse-main` in the [environments repository](https://github.com/ministryofjustice/cloud-platform-environments).
 
 ## Removing
 Currently a manual task:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Concourse CI for the Cloud Platform
 In order to setup concourse initially on a cluster, you will need to have `terraform` (version >= 0.12.13), `kubectl` and `helm` installed.
 
 1. Select the name of the cluster you want to install Concourse CI on, as it appears in the terraform workspaces [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform).
-  
-  `kubectl config use-context <cluster-name>.k8s.integration.dsd.io`
+
+  `kubectl config use-context <cluster-name>.cloud-platform.service.justice.gov.uk`
 
 2. Select the workspace to match the cluster you want to nstall Concourse CI on
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ In order to setup concourse initially on a cluster, you will need to have `terra
 
   `kubectl config use-context <cluster-name>.cloud-platform.service.justice.gov.uk`
 
+Or, if you have `kops` installed:
+
+  `kops export kubecfg <cluster-name>.cloud-platform.service.justice.gov.uk`
+
 2. Select the workspace to match the cluster you want to nstall Concourse CI on
 
   `terraform workspace select <cluster-name>`

--- a/README.md
+++ b/README.md
@@ -32,12 +32,17 @@ Or, if you have `kops` installed:
 Please make sure you define the namespaces `concourse` and `concourse-main` in the [environments repository](https://github.com/ministryofjustice/cloud-platform-environments).
 
 ## Removing
+
 Currently a manual task:
+
 1. Remove `helm` deployment:
+
 ```sh
 helm --kube-context=<context> --tiller-namespace kube-system delete --purge concourse
 ```
+
 2. Destroy terraform managed resources:
+
 ```sh
 cd resources
 terraform select workspace <cluster-name>
@@ -49,4 +54,5 @@ terraform workspace delete <cluster-name>
 The created namespaces are not deleted by `helm` but `terraform` *does* manage the two starting ones (`concourse` and `concourse-main`) and will delete them during `destroy`.
 
 ## Pipelines
+
 Pipeline configuration can be managed in this repository, please read the documentation [here](pipelines/README.md).

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Or, if you have `kops` installed:
 
 4. Create namespaces:
 
-* `kubectl create namespace concourse`
-* `kubectl create namespace concourse-main`
+```
+kubectl create namespace concourse
+kubectl create namespace concourse-main
+```
 
 5. Run terraform to bootstraps a Concourse deployment on a Kubernetes cluster <cluster-name> using the Helm package manager.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Concourse CI for the Cloud Platform
 
 ## Install / Upgrade
-In order to setup concourse initially on a cluster, you will need to have `terraform`, `kubectl` and `helm` installed.
+
+In order to setup concourse initially on a cluster, you will need to have `terraform` (version >= 0.12.13), `kubectl` and `helm` installed.
 
 1. Select the name of the cluster you want to install Concourse CI on, as it appears in the terraform workspaces [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform).
   


### PR DESCRIPTION
* users need to manually create & destroy concourse namespaces
* update cluster naming schema
* add `cd resources` before `terraform apply`
* provide `kops` alternative to target a cluster
* mention that terraform 0.12 is required