### PR TITLE
Add TF_VAR_xxx environment variables to live-1

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -129,6 +129,9 @@ jobs:
             PIPELINE_CLUSTER_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_CLUSTER_STATE_KEY_PREFIX: "cloud-platform/"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_cluster_name: "live-1.cloud-platform.service.justice.gov.uk"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-repo

--- a/pipelines/live-1/main/build-namespace-changes.yaml
+++ b/pipelines/live-1/main/build-namespace-changes.yaml
@@ -121,6 +121,9 @@ jobs:
             PIPELINE_CLUSTER_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_CLUSTER_STATE_KEY_PREFIX: "cloud-platform/"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_cluster_name: "live-1.cloud-platform.service.justice.gov.uk"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-repo

--- a/pipelines/live-1/main/plan-environments.yaml
+++ b/pipelines/live-1/main/plan-environments.yaml
@@ -130,6 +130,9 @@ jobs:
             PIPELINE_CLUSTER_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_CLUSTER_STATE_KEY_PREFIX: "cloud-platform/"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_cluster_name: "live-1.cloud-platform.service.justice.gov.uk"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-live-1-pull-requests


### PR DESCRIPTION
This change should make no difference to the 
current live-1 pipelines, but it is a pre-
requisite for adapting the pipeline code to work
with terraform 0.12 source code.

Terraform 0.12 won't let you pass a variable on
the command-line unless the terraform source code
uses the variable, but this restriction does not
apply to TF_VAR_xxx environment variables.