### PR TITLE
Remove last instance of 'terraform12'

### DIFF
--- a/bin/force-pipeline-state
+++ b/bin/force-pipeline-state
@@ -27,8 +27,8 @@ _tf() {
   echo ">>> creating pipeline resources for $(basename ${2})"
   (
     set -x
-    terraform12 init
-    terraform12 "${1}" -auto-approve | sed -E 's/((content|template):[[:space:]]+)".+"/\1<REDACTED>/'
+    terraform init
+    terraform "${1}" -auto-approve | sed -E 's/((content|template):[[:space:]]+)".+"/\1<REDACTED>/'
   )
   cd $OLDPWD
 }


### PR DESCRIPTION
Everything should refer to 'terraform' now.