### PR TITLE
Add a new pipeline to detect deleted namespaces

### DIFF
--- a/pipelines/live-1/main/namespace-deleter.yaml
+++ b/pipelines/live-1/main/namespace-deleter.yaml
@@ -1,0 +1,57 @@
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: master
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.8
+
+groups:
+- name: live-1
+  jobs: [detect-deleted-namespaces]
+
+jobs:
+  - name: detect-deleted-namespaces
+    serial: true
+    plan:
+      - aggregate:
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: tools-image
+      - task: detect-deleted-namespaces
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            KUBECONFIG_AWS_REGION: eu-west-2
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBE_CONFIG: /tmp/kubeconfig
+            KUBE_CTX: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            SLACK_WEBHOOK: ((slack-hook-id))
+            TF_VAR_cluster_name: live-1.cloud-platform.service.justice.gov.uk
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                bundle install --without development test
+                ./bin/deleted-namespaces.rb


### PR DESCRIPTION
depends on https://github.com/ministryofjustice/cloud-platform-environments/pull/1722

Currently, the script will just post a slack message to tell us
to delete the relevant namespaces. As such, we don't need all the
environment variables configured here. But, once we're happy that
the script works correctly, we will modify it to auto-delete the
namespaces, at which point it *will* need all of these env. vars.
So, I've added all the env vars here, so that a later change
should only need to update the ruby script in the environments
repo, and won't need to change this pipeline.