### PR TITLE
Remove unused env. vars for namespace deleter

### DIFF
--- a/pipelines/live-1/main/namespace-deleter.yaml
+++ b/pipelines/live-1/main/namespace-deleter.yaml
@@ -32,9 +32,6 @@ jobs:
           params:
             AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
-            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
-            KUBECONFIG_AWS_REGION: eu-west-2
-            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
             KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
             KUBECONFIG_S3_KEY: kubeconfig
             KUBE_CONFIG: /tmp/kubeconfig


### PR DESCRIPTION
depends on
https://github.com/ministryofjustice/cloud-platform-environments/pull/1733

Previously, the code this was based upon had to
work on both live-0 and live-1, which are in
different AWS accounts, so in one cluster we
needed two different sets of AWS credentials.

Now that we only have to worry about live-1, we
can be sure that the same AWS credentials that
give us access to the terraform state files will
also give us access to the kubeconfig file's S3
bucket. So, we can reduce complexity by only
using a single set of AWS credentials.