### PR TITLE
Adding remove policy permissions to concourse user

### DIFF
--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -147,6 +147,9 @@ data "aws_iam_policy_document" "policy" {
       "iam:PutRolePolicy",
       "iam:GetRolePolicy",
       "iam:TagRole",
+      "iam:ListInstanceProfilesForRole",
+      "iam:DeleteRolePolicy",
+      "iam:DeleteRole",
     ]
 
     resources = [


### PR DESCRIPTION
Concourse user needs the permissions on resource starting with cloud-platform-*. This is to remove resource related to Elasticsearch module.