### PR TITLE
Add a pipeline to delete manually-created pods

### DIFF
--- a/pipelines/live-1/main/delete-manually-created-pods.yaml
+++ b/pipelines/live-1/main/delete-manually-created-pods.yaml
@@ -49,8 +49,8 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
-            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
             KUBECONFIG: /tmp/kubeconfig
             PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
           run:
@@ -59,11 +59,7 @@ jobs:
             args:
               - -c
               - |
-                (
-                  AWS_ACCESS_KEY_ID="${KUBECONFIG_AWS_ACCESS_KEY_ID}"
-                  AWS_SECRET_ACCESS_KEY="${KUBECONFIG_AWS_SECRET_ACCESS_KEY}"
-                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
-                )
+                aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
                 bundle install --without development test
                 ./bin/delete_manually_created_pods.rb --dry-run # TODO: remove --dry-run
 

--- a/pipelines/live-1/main/delete-manually-created-pods.yaml
+++ b/pipelines/live-1/main/delete-manually-created-pods.yaml
@@ -1,0 +1,76 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#cloud-platform-notify'
+  silent: true
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished deleting old, manually-created pods'
+  title: 'Delete manually-created-pods'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/delete-manually-created-pods'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: master
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.9
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+groups:
+- name: live-1
+  jobs: [delete-manually-created-pods-live-1]
+
+jobs:
+  - name: delete-manually-created-pods-live-1
+    serial: true
+    plan:
+      - aggregate:
+        - get: cloud-platform-environments-repo
+        - get: tools-image
+      - task: run-script
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                (
+                  AWS_ACCESS_KEY_ID="${KUBECONFIG_AWS_ACCESS_KEY_ID}"
+                  AWS_SECRET_ACCESS_KEY="${KUBECONFIG_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                bundle install --without development test
+                ./bin/delete_manually_created_pods.rb --dry-run # TODO: remove --dry-run
+
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/live-1/main/delete-manually-created-pods.yaml
+++ b/pipelines/live-1/main/delete-manually-created-pods.yaml
@@ -23,6 +23,10 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-day
+  type: time
+  source:
+    interval: 24h
 
 resource_types:
 - name: slack-notification
@@ -40,6 +44,8 @@ jobs:
     serial: true
     plan:
       - aggregate:
+        - get: every-day
+          trigger: true
         - get: cloud-platform-environments-repo
         - get: tools-image
       - task: run-script

--- a/pipelines/live-1/main/delete-manually-created-pods.yaml
+++ b/pipelines/live-1/main/delete-manually-created-pods.yaml
@@ -61,7 +61,7 @@ jobs:
               - |
                 aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
                 bundle install --without development test
-                ./bin/delete_manually_created_pods.rb --dry-run # TODO: remove --dry-run
+                ./bin/delete_manually_created_pods.rb
 
         on_failure:
           put: slack-alert


### PR DESCRIPTION
This pipeline runs the deletion script once per day.

depends on https://github.com/ministryofjustice/cloud-platform-environments/pull/1789
closes https://github.com/ministryofjustice/cloud-platform/issues/1403
closes https://github.com/ministryofjustice/cloud-platform/issues/1507