### PR TITLE
Use version 1.7 of the smoke-tests image

### DIFF
--- a/pipelines/live-1/main/integration-tests.yaml
+++ b/pipelines/live-1/main/integration-tests.yaml
@@ -16,7 +16,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
-    tag: latest
+    tag: 1.7
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
This version has a working /usr/local/bin/rspec executable.