### PR TITLE
terraform variable to specify clusters (VPC/Subnets tags) as variables

### DIFF
--- a/pipelines/live-1/main/divergence-networking.yaml
+++ b/pipelines/live-1/main/divergence-networking.yaml
@@ -56,6 +56,7 @@ jobs:
             KUBECONFIG_S3_KEY: kubeconfig
             KUBECONFIG: /tmp/kubeconfig
             KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            TF_VAR_cluster_names: '["live-1.cloud-platform.service.justice.gov.uk","manager"]'
           inputs:
           - name: cloud-platform-infrastructure-repo
             path: ./


### PR DESCRIPTION
This is required by terraform when you have multiple cluster within a VPC