### PR TITLE
Use v2.17 of cloud-platform-environments-checker

### DIFF
--- a/pipelines/live-1/main/check-environment.yaml
+++ b/pipelines/live-1/main/check-environment.yaml
@@ -11,7 +11,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: 2.16
+    tag: 2.17
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
Depends on
https://github.com/ministryofjustice/cloud-platform-environments-checker/pull/22

This version fixes a security vulnerability.