### PR TITLE
Use version 2.18 of the environments checker

### DIFF
--- a/pipelines/live-1/main/check-environment.yaml
+++ b/pipelines/live-1/main/check-environment.yaml
@@ -11,7 +11,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: 2.17
+    tag: 2.18
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
This version won't include any namespaces in the orphans list if
they're created via terraform code in the infrastructure repo.

Depends on
https://github.com/ministryofjustice/cloud-platform-environments-checker/pull/23