### PR TITLE
New pipelines and more IAM permissions

### DIFF
--- a/pipelines/live-1/main/divergence-cloud-platform-concourse.yaml
+++ b/pipelines/live-1/main/divergence-cloud-platform-concourse.yaml
@@ -22,10 +22,10 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-hour
+- name: every-4-hours
   type: time
   source:
-    interval: 1h
+    interval: 4h
 
 resource_types:
 - name: slack-notification
@@ -39,7 +39,7 @@ jobs:
     serial: true
     plan:
       - aggregate:
-        - get: every-hour
+        - get: every-4-hours
           trigger: true
         - get: cloud-platform-concourse-repo
           trigger: false

--- a/pipelines/live-1/main/divergence-cloud-platform-concourse.yaml
+++ b/pipelines/live-1/main/divergence-cloud-platform-concourse.yaml
@@ -1,0 +1,81 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-concourse-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-concourse.git
+    branch: master
+    git_crypt_key: ((cloud-platform-concourse-git-crypt.key))
+- name: cloud-platform-tools-terraform
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
+    tag: 0.1
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-hour
+  type: time
+  source:
+    interval: 1h
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+jobs:
+  - name: divergence-cloud-platform-concourse
+    serial: true
+    plan:
+      - aggregate:
+        - get: every-hour
+          trigger: true
+        - get: cloud-platform-concourse-repo
+          trigger: false
+        - get: cloud-platform-tools-terraform
+          trigger: false
+      - task: divergence-cloud-platform-concourse
+        image: cloud-platform-tools-terraform
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          inputs:
+          - name: cloud-platform-concourse-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                kubectl get nodes
+                cd resources
+                cp-tools terraform check-divergence --workspace live-1
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/live-1/main/divergence-cloud-platform-kops.yaml
+++ b/pipelines/live-1/main/divergence-cloud-platform-kops.yaml
@@ -22,10 +22,10 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-hour
+- name: every-4-hours
   type: time
   source:
-    interval: 1h
+    interval: 4h
 
 resource_types:
 - name: slack-notification
@@ -39,7 +39,7 @@ jobs:
     serial: true
     plan:
       - aggregate:
-        - get: every-hour
+        - get: every-4-hours
           trigger: true
         - get: cloud-platform-infrastructure-repo
           trigger: false

--- a/pipelines/live-1/main/divergence-cloud-platform-kops.yaml
+++ b/pipelines/live-1/main/divergence-cloud-platform-kops.yaml
@@ -1,0 +1,81 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: master
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+- name: cloud-platform-tools-terraform
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
+    tag: 0.1
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-hour
+  type: time
+  source:
+    interval: 1h
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+jobs:
+  - name: divergence-cloud-platform
+    serial: true
+    plan:
+      - aggregate:
+        - get: every-hour
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: cloud-platform-tools-terraform
+          trigger: false
+      - task: check-divergence-k8s-components
+        image: cloud-platform-tools-terraform
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                kubectl get nodes
+                cd terraform/cloud-platform/
+                cp-tools terraform check-divergence --workspace live-1
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/live-1/main/divergence-k8s-components.yaml
+++ b/pipelines/live-1/main/divergence-k8s-components.yaml
@@ -22,10 +22,10 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-hour
+- name: every-4-hours
   type: time
   source:
-    interval: 1h
+    interval: 4h
 
 resource_types:
 - name: slack-notification
@@ -39,7 +39,7 @@ jobs:
     serial: true
     plan:
       - aggregate:
-        - get: every-hour
+        - get: every-4-hours
           trigger: true
         - get: cloud-platform-infrastructure-repo
           trigger: false

--- a/pipelines/live-1/main/divergence-networking.yaml
+++ b/pipelines/live-1/main/divergence-networking.yaml
@@ -21,10 +21,10 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-hour
+- name: every-4-hours
   type: time
   source:
-    interval: 1h
+    interval: 4h
 
 resource_types:
 - name: slack-notification
@@ -38,7 +38,7 @@ jobs:
     serial: true
     plan:
       - aggregate:
-        - get: every-hour
+        - get: every-4-hours
           trigger: true
         - get: cloud-platform-infrastructure-repo
           trigger: false

--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -46,13 +46,30 @@ data "aws_iam_policy_document" "policy" {
       "iam:DeleteUserPolicy",
       "iam:ListGroupsForUser",
       "iam:PutUserPermissionsBoundary",
+      "iam:GetPolicy",
+      "iam:ListEntitiesForPolicy",
+      "iam:GetPolicyVersion",
       "iam:DeleteUserPermissionsBoundary",
+
     ]
 
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/system/*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/*",
     ]
   }
+
+  statement {
+    actions = [
+      "iam:GetUser",
+      "iam:ListAccessKeys",
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/*",
+    ]
+  }
+
 
   statement {
     actions = [
@@ -181,47 +198,8 @@ data "aws_iam_policy_document" "policy" {
       "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
       "ec2:TerminateInstances",
       # Required by terraform-aws module
-      "ec2:DescribeAccountAttributes",
-      "ec2:DescribeAddresses",
-      "ec2:DescribeClassicLinkInstances",
-      "ec2:DescribeClientVpnEndpoints",
-      "ec2:DescribeCustomerGateways",
-      "ec2:DescribeDhcpOptions",
-      "ec2:DescribeEgressOnlyInternetGateways",
-      "ec2:DescribeFlowLogs",
-      "ec2:DescribeInternetGateways",
-      "ec2:DescribeMovingAddresses",
-      "ec2:DescribeNatGateways",
-      "ec2:DescribeNetworkAcls",
-      "ec2:DescribeNetworkInterfaceAttribute",
-      "ec2:DescribeNetworkInterfacePermissions",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribePrefixLists",
-      "ec2:DescribeRouteTables",
-      "ec2:DescribeSecurityGroupReferences",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeStaleSecurityGroups",
-      "ec2:DescribeSubnets",
-      "ec2:DescribeTags",
-      "ec2:DescribeTrafficMirrorFilters",
-      "ec2:DescribeTrafficMirrorSessions",
-      "ec2:DescribeTrafficMirrorTargets",
-      "ec2:DescribeTransitGateways",
-      "ec2:DescribeTransitGatewayVpcAttachments",
-      "ec2:DescribeTransitGatewayRouteTables",
-      "ec2:DescribeVpcAttribute",
-      "ec2:DescribeVpcClassicLink",
-      "ec2:DescribeVpcClassicLinkDnsSupport",
-      "ec2:DescribeVpcEndpoints",
-      "ec2:DescribeVpcEndpointConnectionNotifications",
-      "ec2:DescribeVpcEndpointConnections",
-      "ec2:DescribeVpcEndpointServiceConfigurations",
-      "ec2:DescribeVpcEndpointServicePermissions",
-      "ec2:DescribeVpcEndpointServices",
-      "ec2:DescribeVpcPeeringConnections",
-      "ec2:DescribeVpcs",
-      "ec2:DescribeVpnConnections",
-      "ec2:DescribeVpnGateways"
+      "ec2:Describe*",
+      "autoscaling:Describe*",
     ]
 
     resources = [
@@ -264,6 +242,7 @@ data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
       "route53:CreateHostedZone",
+      "route53:ListHostedZones",
     ]
 
     resources = [
@@ -300,6 +279,17 @@ data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
       "sns:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "acm:DescribeCertificate",
+      "acm:ListTagsForCertificate",
     ]
 
     resources = [
@@ -346,6 +336,7 @@ data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
       "iam:ListPolicies",
+      "iam:GetInstanceProfile"
     ]
 
     resources = [

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -199,7 +199,6 @@ resource "kubernetes_secret" "concourse_main_cp_infrastructure_git_crypt" {
   }
 }
 
-
 resource "helm_release" "concourse" {
   name          = "concourse"
   namespace     = "concourse"


### PR DESCRIPTION
- Changed divergence pipelines to run every 4h
- Added two new pipelines: 
  * divergence-cloud-platform-concourse: Check concourse repo divergences
  * divergence-cloud-platform-kops: check kops divergences
- Using wildcards to simply the permissions
