### PR TITLE
Increase concourse workers from 2 to 4

### DIFF
--- a/resources/templates/values.yaml
+++ b/resources/templates/values.yaml
@@ -1322,7 +1322,7 @@ worker:
 
   ## Number of replicas.
   ##
-  replicas: 2
+  replicas: 4
 
   ## Array of extra containers to run alongside the Concourse worker
   ## container.


### PR DESCRIPTION
This will require a terraform apply. According to
plan, this will update the helm release in-place.

closes https://github.com/ministryofjustice/cloud-platform/issues/1575