### PR TITLE
Update divergence pipelines to the most recent image

### DIFF
--- a/pipelines/live-1/main/divergence-cloud-platform-concourse.yaml
+++ b/pipelines/live-1/main/divergence-cloud-platform-concourse.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
-    tag: 0.1
+    tag: 0.2
 - name: slack-alert
   type: slack-notification
   source:
@@ -67,7 +67,6 @@ jobs:
               - |
                 aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
                 kubectl config use-context ${KUBE_CLUSTER}
-                kubectl get nodes
                 cd resources
                 cp-tools terraform check-divergence --workspace live-1
           outputs:

--- a/pipelines/live-1/main/divergence-cloud-platform-kops.yaml
+++ b/pipelines/live-1/main/divergence-cloud-platform-kops.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
-    tag: 0.1
+    tag: 0.2
 - name: slack-alert
   type: slack-notification
   source:
@@ -67,7 +67,6 @@ jobs:
               - |
                 aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
                 kubectl config use-context ${KUBE_CLUSTER}
-                kubectl get nodes
                 cd terraform/cloud-platform/
                 cp-tools terraform check-divergence --workspace live-1
           outputs:

--- a/pipelines/live-1/main/divergence-k8s-components.yaml
+++ b/pipelines/live-1/main/divergence-k8s-components.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
-    tag: 0.1
+    tag: 0.2
 - name: slack-alert
   type: slack-notification
   source:
@@ -67,7 +67,6 @@ jobs:
               - |
                 aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
                 kubectl config use-context ${KUBE_CLUSTER}
-                kubectl get nodes
                 cd terraform/cloud-platform-components/
                 cp-tools terraform check-divergence --workspace live-1
           outputs:

--- a/pipelines/live-1/main/divergence-networking.yaml
+++ b/pipelines/live-1/main/divergence-networking.yaml
@@ -16,7 +16,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
-    tag: 0.1
+    tag: 0.2
 - name: slack-alert
   type: slack-notification
   source:
@@ -67,7 +67,6 @@ jobs:
               - |
                 aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
                 kubectl config use-context ${KUBE_CLUSTER}
-                kubectl get nodes
                 cd terraform/cloud-platform-network/
                 cp-tools terraform check-divergence --workspace live-1
           outputs:


### PR DESCRIPTION
Upgrade to a newer image and remove the `kubectl get nodes` (initially there to debug k8s connection)