### PR TITLE
Added servicemonitor resource to concourse

### DIFF
--- a/resources/concourse-servicemonitor.yaml
+++ b/resources/concourse-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: concourse
+  namespace: concourse
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: concourse-web
+  namespaceSelector:
+    matchNames:
+      - concourse
+  endpoints:
+    - port: prometheus
+      interval: 30s
+

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -546,6 +546,24 @@ resource "kubernetes_secret" "concourse_main_dockerhub" {
   }
 }
 
+# For ServiceMonitor
+
+resource "null_resource" "priority_classes" {
+  provisioner "local-exec" {
+    command = "kubectl apply -f ${path.module}/concourse-servicemonitor.yaml"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kubectl delete -f ${path.module}/concourse-servicemonitor.yaml"
+  }
+
+  triggers = {
+    contents = filesha1("${path.module}/concourse-servicemonitor.yaml")
+  }
+}
+
+
 ##########
 # Locals #
 ##########


### PR DESCRIPTION
ServiceMonitor resource included as a YAML file because Kubernetes Provider doesn't include CRDs yet.