### PR TITLE
change serial to false, for change pipeline

### DIFF
--- a/pipelines/live-1/main/build-namespace-changes.yaml
+++ b/pipelines/live-1/main/build-namespace-changes.yaml
@@ -37,7 +37,7 @@ groups:
 
 jobs:
   - name: apply-namespace-changes-live-1
-    serial: true
+    serial: false
     plan:
       - aggregate:
         - get: cloud-platform-environments-repo


### PR DESCRIPTION
The aim of this PR is to enable concurrent runs of the `build-namespace-change` pipeline.