### PR TITLE
Conditional to display or not terraform outputs

### DIFF
--- a/pipelines/live-1/main/divergence-k8s-components.yaml
+++ b/pipelines/live-1/main/divergence-k8s-components.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
-    tag: 0.2
+    tag: 0.3
 - name: slack-alert
   type: slack-notification
   source:
@@ -68,7 +68,7 @@ jobs:
                 aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
                 kubectl config use-context ${KUBE_CLUSTER}
                 cd terraform/cloud-platform-components/
-                cp-tools terraform check-divergence --workspace live-1
+                cp-tools terraform check-divergence --workspace live-1 --display-tf-output=false
           outputs:
             - name: metadata
         on_failure:


### PR DESCRIPTION
`terraform plan` can be dangerous because some of the diffs can include credentials we use in our internal helm-chart's values (Prometheus-operator is an example). 

It was added to the cp-tools CLI the option to set `--display-tf-output=false` in case it isn't desired to display `terraform plan` output 