### PR TITLE
Add gitops repo and terraform env vars

### DIFF
--- a/pipelines/live-1/main/build-environments.yaml
+++ b/pipelines/live-1/main/build-environments.yaml
@@ -14,6 +14,11 @@ resources:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: master
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: cloud-platform-terraform-gitops-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-terraform-gitops.git
+    branch: master
 - name: tools-image
   type: docker-image
   source:
@@ -48,6 +53,8 @@ jobs:
           trigger: true
         - get: cloud-platform-environments-repo
           trigger: false
+        - get: cloud-platform-terraform-gitops-repo
+          trigger: true
         - get: tools-image
       - task: apply-environments
         image: tools-image
@@ -71,6 +78,9 @@ jobs:
             PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
             TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"


### PR DESCRIPTION
What's in this PR?
---
The work to implement a gitops-namespace process in the environments repo requires the `build-environments` pipeline to authenticate to concourse. The changes in this PR will set a few environment variables that all the concourse terraform provider to read and authenticate. 

It will also check for changes in the [terraform-gitops](https://github.com/ministryofjustice/cloud-platform-terraform-gitops) repository and trigger the pipeline if a change to master has occurred.

This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/1158.