### PR TITLE
Fixed pipeline adding a get step

### DIFF
--- a/pipelines/manager/main/tools-image.yaml
+++ b/pipelines/manager/main/tools-image.yaml
@@ -83,6 +83,8 @@ jobs:
       - aggregate:
         - get: repo
           trigger: true
+        - get: image-base-cp
+          trigger: true
       - task: ensure-repository-exists
         image: image-base-cp
         config:


### PR DESCRIPTION
We were getting the following error from the tools-image pipeline: 

```console
missing image artifact source: image-base-cp

make sure there's a corresponding 'get' step, or a task that produces it as an output
```

Adding the `get` looks to fix the problem: https://concourse.apps.manager.cloud-platform.service.justice.gov.uk/teams/main/pipelines/tools-image/jobs/build-cp/builds/4