### PR TITLE
ServiceAccount for concourse

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -542,7 +542,7 @@ resource "null_resource" "priority_classes" {
 
 resource "kubernetes_service_account" "concourse_build_environments" {
   metadata {
-    name = "concourse-build-environments"
+    name      = "concourse-build-environments"
     namespace = "kube-system"
   }
 }
@@ -552,7 +552,7 @@ resource "kubernetes_cluster_role_binding" "concourse_build_environments" {
   metadata {
     name = "concourse-build-environments"
   }
-  
+
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"

--- a/resources/main.tf
+++ b/resources/main.tf
@@ -537,6 +537,34 @@ resource "null_resource" "priority_classes" {
   }
 }
 
+# Concourse Service Account
+
+
+resource "kubernetes_service_account" "concourse_build_environments" {
+  metadata {
+    name = "concourse-build-environments"
+    namespace = "kube-system"
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "concourse_build_environments" {
+
+  metadata {
+    name = "concourse-build-environments"
+  }
+  
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.concourse_build_environments.metadata.0.name
+    namespace = "kube-system"
+  }
+
+}
 
 ##########
 # Locals #


### PR DESCRIPTION
Added cluster-admin service account for concourse. It replaces https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/live-1.cloud-platform.service.justice.gov.uk/kube-system/concourse-build-environments.yaml

