### PR TITLE
Bind cluster-web serviceaccount to cluster-admin

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -563,6 +563,11 @@ resource "kubernetes_cluster_role_binding" "concourse_build_environments" {
     name      = kubernetes_service_account.concourse_build_environments.metadata.0.name
     namespace = "kube-system"
   }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "concourse-web"
+    namespace = "concourse"
+  }
 
 }
 


### PR DESCRIPTION
This will allow the concourse-web service account full access to create, read, update and delete Kubernetes resources in the Manager cluster