### PR TITLE
Remove the EXECUTION_CONTEXT env. var. from tests

### DIFF
--- a/pipelines/manager/main/integration-tests.yaml
+++ b/pipelines/manager/main/integration-tests.yaml
@@ -62,7 +62,6 @@ jobs:
           KUBECONFIG_S3_KEY: kubeconfig
           KUBECONFIG: /tmp/kubeconfig
           KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
-          EXECUTION_CONTEXT: integration-test-pipeline
         run:
           path: /bin/sh
           dir: cloud-platform-infrastructure-repo


### PR DESCRIPTION
The test pipeline set EXECUTION_CONTEXT to "integration-tests" to
enable an additional delay between shell commands when the tests
were run via the concourse pipeline.
This extra delay has now been removed, so this env. var. is no
longer needed.

related to
https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/568