### PR TITLE
Pin helm version to  "0.10.4"

### DIFF
--- a/resources/main.tf
+++ b/resources/main.tf
@@ -13,6 +13,12 @@ provider "aws" {
   region  = "eu-west-2"
 }
 
+provider "helm" {
+  version = "0.10.4"
+  kubernetes {
+  }
+}
+
 data "terraform_remote_state" "network" {
   backend = "s3"
 


### PR DESCRIPTION
Pin helm provider version to "0.10.4"

This is because latest provider version 1.0 is compatible for helm3 and we are still using helm2

    https://github.com/terraform-providers/terraform-provider-helm#%EF%B8%8F-project-update-helm-3