### PR TITLE
Added git_crypt_key to cloud-platform-infrastructure job

### DIFF
--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -12,6 +12,7 @@ resources:
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
     branch: master
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:


### PR DESCRIPTION
In order to plan against components, the tfvars must be decrypted. This PR add the git-crypt key to it. 