### PR TITLE
NEW PIPELINE: manual-snapshots 

### DIFF
--- a/pipelines/manager/main/manual-snapshots.yaml
+++ b/pipelines/manager/main/manual-snapshots.yaml
@@ -1,0 +1,77 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-tools-terraform
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
+    tag: 0.3
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-12-hours
+  type: time
+  source:
+    interval: 12h
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+
+jobs:
+  - name: manual-snapshots-checker
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-12-hours
+          trigger: true
+        - get: cloud-platform-tools-terraform
+          trigger: false
+      - task: manual-snapshots-checker
+        image: cloud-platform-tools-terraform
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            ALERT_WHEN_SNAPSHOTS_PERCENT_GT: 70
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                RdsLimits=( $(aws rds describe-account-attributes --region ${AWS_REGION} --query 'AccountQuotas[?starts_with(AccountQuotaName, `ManualSnapshots`) == `true`]|[].[Used,Max]' --output text | awk '{print $1, $2}') )
+
+                AlertOn=$(( (${RdsLimits[1]} * ${ALERT_WHEN_SNAPSHOTS_PERCENT_GT}) / 100 ))
+
+                echo "Snapshot number: ${RdsLimits[0]}            Snapshot limit: ${RdsLimits[1]}"
+                echo "Alerting if snapshots are more than ${AlertOn} (${ALERT_WHEN_SNAPSHOTS_PERCENT_GT}% of the limit)"
+
+                if [ ${RdsLimits[0]} -ge ${AlertOn} ]; then
+                   echo "Ups, number of snapshots (${RdsLimits[0]}) are more than ${ALERT_WHEN_SNAPSHOTS_PERCENT_GT}% (${AlertOn}) of the limits ( ${RdsLimits[1]} ). Please cleanup"
+                   exit 1
+                else 
+                   echo "Happy life! Snapshots are fine :-)"
+                   exit 0
+                fi 
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
Added new pipeline in order to protect us from reaching manual-snapshots AWS limits

It can be parametrizable with `ALERT_WHEN_SNAPSHOTS_PERCENT_GT` variable, which specifies when we reach a percentage number of our allowance.

When manual snapshots reach the percentage (`ALERT_WHEN_SNAPSHOTS_PERCENT_GT`) pipeline fails and send an alert