### PR TITLE
Revert "Remove EXECUTION_CONTEXT from tests"

### DIFF
--- a/pipelines/manager/main/integration-tests.yaml
+++ b/pipelines/manager/main/integration-tests.yaml
@@ -62,6 +62,7 @@ jobs:
           KUBECONFIG_S3_KEY: kubeconfig
           KUBECONFIG: /tmp/kubeconfig
           KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          EXECUTION_CONTEXT: integration-test-pipeline
         run:
           path: /bin/sh
           dir: cloud-platform-infrastructure-repo


### PR DESCRIPTION
This reverts commit c928a7a348358eeb10e6b77c531cb8298623be38.

It seems that we need to slow the integration tests down so that
they don't hit the AWS route53 API so hard.

This change relates to
https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/584

It reintroduces a delay between each command executed, when the
integration tests are run via the concourse pipeline.