### PR TITLE
Update tools-image from 1.9 to 1.12

### DIFF
--- a/pipelines/manager/main/bootstrap.yaml
+++ b/pipelines/manager/main/bootstrap.yaml
@@ -13,7 +13,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 
 jobs:
   - name: bootstrap-pipelines

--- a/pipelines/manager/main/build-environments.yaml
+++ b/pipelines/manager/main/build-environments.yaml
@@ -23,7 +23,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/build-namespace-changes.yaml
+++ b/pipelines/manager/main/build-namespace-changes.yaml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/delete-manually-created-pods.yaml
+++ b/pipelines/manager/main/delete-manually-created-pods.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/how-out-of-date-are-we.yaml
+++ b/pipelines/manager/main/how-out-of-date-are-we.yaml
@@ -3,7 +3,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 - name: every-24-hours
   type: time
   source:

--- a/pipelines/manager/main/namespace-deleter.yaml
+++ b/pipelines/manager/main/namespace-deleter.yaml
@@ -9,7 +9,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 
 groups:
 - name: live-1

--- a/pipelines/manager/main/plan-environments.yaml
+++ b/pipelines/manager/main/plan-environments.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 
 groups:
 - name: live-1

--- a/pipelines/manager/main/recycle-node.yaml
+++ b/pipelines/manager/main/recycle-node.yaml
@@ -16,7 +16,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/tools-image.yaml
+++ b/pipelines/manager/main/tools-image.yaml
@@ -9,7 +9,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.9
+    tag: 1.12
     username: ((cloud-platform-environments-dockerhub.dockerhub_username))
     password: ((cloud-platform-environments-dockerhub.dockerhub_access_token))
 


### PR DESCRIPTION
The latest version of the tools image has a later
version of kops, to match the current state of
live-1
This commit updates all pipelines which use the
1.9 version to use the 1.12 image tag.
Earlier versions of kops may not parse the latest
kops state definition YAML file.