### PR TITLE
New pipeline: build-test-clusters

### DIFF
--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -67,7 +67,6 @@ jobs:
               - |
                 mkdir ${HOME}/.aws
                 echo "[moj-cp]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-( 
-                echo "[moj-dsd]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-(
                 export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
                 echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
                 ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -1,0 +1,81 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: master
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.13
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+groups:
+- name: cluster-test
+  jobs:
+    - build-test-cluster
+
+jobs:
+  - name: build-test-cluster
+    serial: true
+    plan:
+      - in_parallel:
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: tools-image
+          trigger: false
+      - task: build-test-cluster
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            AWS_PROFILE: moj-cp
+            AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+            AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+            AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+            KOPS_STATE_STORE: s3://cloud-platform-kops-state
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-( 
+                echo "[moj-dsd]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-(
+                export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
+                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
+                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+    

--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -112,33 +112,33 @@ data "aws_iam_policy_document" "policy" {
   # Due to build-test-cluster pipeline we need to give moe privileges to the concourse user
   # in order to create/destroy vpc, resources and roles. 
 
-    statement {
-      actions = [
-        "ec2:*",
-        "acm:RequestCertificate",
+  statement {
+    actions = [
+      "ec2:*",
+      "acm:RequestCertificate",
 
-        "iam:CreateRole",
-        "iam:AttachRolePolicy",
-        "iam:GetRole",
-        "iam:PutRolePolicy",
-        "iam:GetRolePolicy",
-        "iam:TagRole",
-        "iam:ListInstanceProfilesForRole",
-        "iam:DeleteRolePolicy",
-        "iam:DeleteRole",
+      "iam:CreateRole",
+      "iam:AttachRolePolicy",
+      "iam:GetRole",
+      "iam:PutRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:TagRole",
+      "iam:ListInstanceProfilesForRole",
+      "iam:DeleteRolePolicy",
+      "iam:DeleteRole",
 
-        "iam:CreateInstanceProfile",      # terraform/cloud-platform (bastion module)
-        "iam:AddRoleToInstanceProfile",   # terraform/cloud-platform (bastion module)
-        "iam:PassRole",                   # terraform/cloud-platform
-        "autoscaling:*",                  # kops create
-        "route53:ListHostedZonesByName",  # kops create
-        "elasticloadbalancing:*",         # kops create
-        "iam:UpdateAssumeRolePolicy"      # because of integration tests ("is not authorized to perform: iam:UpdateAssumeRolePolicy on resource: role integration-test-kiam-iam-role)
-      ]
+      "iam:CreateInstanceProfile",     # terraform/cloud-platform (bastion module)
+      "iam:AddRoleToInstanceProfile",  # terraform/cloud-platform (bastion module)
+      "iam:PassRole",                  # terraform/cloud-platform
+      "autoscaling:*",                 # kops create
+      "route53:ListHostedZonesByName", # kops create
+      "elasticloadbalancing:*",        # kops create
+      "iam:UpdateAssumeRolePolicy"     # because of integration tests ("is not authorized to perform: iam:UpdateAssumeRolePolicy on resource: role integration-test-kiam-iam-role)
+    ]
 
-      resources = [
-        "*",
-      ]
+    resources = [
+      "*",
+    ]
   }
 
   # In order to create the kubeadmin file using: 

--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -109,6 +109,38 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
 
+  # Due to build-test-cluster pipeline we need to give moe privileges to the concourse user
+  # in order to create/destroy vpc, resources and roles. 
+
+    statement {
+      actions = [
+        "ec2:*",
+        "acm:RequestCertificate",
+
+        "iam:CreateRole",
+        "iam:AttachRolePolicy",
+        "iam:GetRole",
+        "iam:PutRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:TagRole",
+        "iam:ListInstanceProfilesForRole",
+        "iam:DeleteRolePolicy",
+        "iam:DeleteRole",
+
+        "iam:CreateInstanceProfile",      # terraform/cloud-platform (bastion module)
+        "iam:AddRoleToInstanceProfile",   # terraform/cloud-platform (bastion module)
+        "iam:PassRole",                   # terraform/cloud-platform
+        "autoscaling:*",                  # kops create
+        "route53:ListHostedZonesByName",  # kops create
+        "elasticloadbalancing:*",         # kops create
+        "iam:UpdateAssumeRolePolicy"      # because of integration tests ("is not authorized to perform: iam:UpdateAssumeRolePolicy on resource: role integration-test-kiam-iam-role)
+      ]
+
+      resources = [
+        "*",
+      ]
+  }
+
   # In order to create the kubeadmin file using: 
   # aws eks --region REGION update-kubeconfig --name CLUSTER
   statement {


### PR DESCRIPTION
This pipeline gets triggered manually and it does create a cluster with the format name of `cp-ddmm-HHMM`. 

In order to grant ability to create clusters and VPC we had to grant to the concourse users with new privileges.