### PR TITLE
Change the build pipeline to run every 2 hours

### DIFF
--- a/pipelines/manager/main/build-environments.yaml
+++ b/pipelines/manager/main/build-environments.yaml
@@ -28,10 +28,10 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-60m
+- name: every-120m
   type: time
   source:
-    interval: 60m
+    interval: 120m
 
 resource_types:
 - name: slack-notification
@@ -49,7 +49,7 @@ jobs:
     serial: true
     plan:
       - aggregate:
-        - get: every-60m
+        - get: every-120m
           trigger: true
         - get: cloud-platform-environments-repo
           trigger: false


### PR DESCRIPTION
Currently, the build pipeline takes an average of an hour to run,
so triggering it every hour means it's always running. This commit
decreases the frequency from every 60m to every 120m