### PR TITLE
Fixed EKS divergence pipeline

### DIFF
--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -120,7 +120,8 @@ jobs:
               - -c
               - |
                 cd terraform/cloud-platform-eks/
-                cp-tools terraform check-divergence --workspace manager --var-file vars/manager.tfvars
+                echo -e "cluster_node_count=\"4\"\nworker_node_machine_type=\"m4.large\"\nvpc_name=\"live-1\"" > manager.tfvars
+                cp-tools terraform check-divergence --workspace manager --var-file manager.tfvars
           outputs:
             - name: metadata        
         on_failure:


### PR DESCRIPTION
EKS divergence pipeline has been failing for a while because of [`vars/` directory](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/acddc179391da93d0ca25a059eb48fa410113466/terraform/cloud-platform-eks/vars) was removed. This PR adds a tfvars dynamically at run time.

In the future, it would be useful to add support for defining terraform variables within cp-tool CLI

