### PR TITLE
Run the node-recycler every 8 hours, 7 days/week

### DIFF
--- a/pipelines/manager/main/recycle-node.yaml
+++ b/pipelines/manager/main/recycle-node.yaml
@@ -21,13 +21,11 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-weekday
+- name: every-8h
   type: time
   source:
-    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
-    start: 11:00
-    stop: 11:30
-    location: Europe/London
+    interval: 8h
+
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -44,7 +42,7 @@ jobs:
   serial: true
   plan:
     - aggregate:
-      - get: every-weekday
+      - get: every-8h
         trigger: true
       - get: tools-image
       - get: cloud-platform-infrastructure-repo


### PR DESCRIPTION
Nodes are sometimes filling up their local disk, because nodes persist
for a long time (around 3 weeks, currently).

This change significantly accelerates the speed at which nodes should be
recycled (from 5 to 21 times/week, barring blockages due to manually
created pods).

NB: I haven't tested this change, but it if doesn't work, it should be
obvious and harmless.