### PR TITLE
Fix how-out-of-date-are-we wrt. cert-manager

### DIFF
--- a/pipelines/manager/main/how-out-of-date-are-we.yaml
+++ b/pipelines/manager/main/how-out-of-date-are-we.yaml
@@ -39,6 +39,7 @@ jobs:
                 aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
                 kubectl config use-context ${KUBE_CLUSTER}
                 helm init --client-only
+                helm repo add jetstack https://charts.jetstack.io
                 helm repo update
                 helm plugin install https://github.com/bacongobbler/helm-whatup
                 helm whatup


### PR DESCRIPTION
This commit adds the jetstack helm repo, which enables `helm whatup` to
report on cert-manager. Without this, the version of cert-manager is not
visible on this page:
https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk/helm_whatup