### PR TITLE
Updated pipelines to use ministryofjustice/cloud-platform-tools:1.15

### DIFF
--- a/pipelines/manager/main/build-environments.yaml
+++ b/pipelines/manager/main/build-environments.yaml
@@ -23,7 +23,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.15
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/build-namespace-changes.yaml
+++ b/pipelines/manager/main/build-namespace-changes.yaml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.15
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.13
+    tag: 1.15
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/delete-manually-created-pods.yaml
+++ b/pipelines/manager/main/delete-manually-created-pods.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.15
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/namespace-deleter.yaml
+++ b/pipelines/manager/main/namespace-deleter.yaml
@@ -9,7 +9,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.15
 
 groups:
 - name: live-1

--- a/pipelines/manager/main/plan-environments.yaml
+++ b/pipelines/manager/main/plan-environments.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.15
 
 groups:
 - name: live-1

--- a/pipelines/manager/main/recycle-node.yaml
+++ b/pipelines/manager/main/recycle-node.yaml
@@ -16,7 +16,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.15
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/tools-image.yaml
+++ b/pipelines/manager/main/tools-image.yaml
@@ -9,7 +9,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.15
     username: ((cloud-platform-environments-dockerhub.dockerhub_username))
     password: ((cloud-platform-environments-dockerhub.dockerhub_access_token))
 


### PR DESCRIPTION
Which contains upgraded kops(1.15.1) and kubectl version(1.15.10)