### PR TITLE
Use HOODAW updater 1.4

### DIFF
--- a/pipelines/manager/main/how-out-of-date-are-we.yaml
+++ b/pipelines/manager/main/how-out-of-date-are-we.yaml
@@ -3,7 +3,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: 1.3
+    tag: 1.4
 - name: every-24-hours
   type: time
   source:


### PR DESCRIPTION
This version has a tweaked `update.sh` script to accomodate the fact
that concourse pipelines ignore the docker image WORKDIR, and execute
whatever command you specify from the root directory of the docker image.