### PR TITLE
Run the HOODAW updater every hour

### DIFF
--- a/pipelines/manager/main/how-out-of-date-are-we.yaml
+++ b/pipelines/manager/main/how-out-of-date-are-we.yaml
@@ -4,10 +4,10 @@ resources:
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
     tag: 1.4
-- name: every-24-hours
+- name: every-hour
   type: time
   source:
-    interval: 24h
+    interval: 60m
 
 
 jobs:
@@ -15,7 +15,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-24-hours
+        - get: every-hour
           trigger: true
         - get: updater-image
       - task: how-out-of-date-are-we


### PR DESCRIPTION
The HOODAW updater works perfectly when I trigger the pipeline via the
concourse web interface, but although it was running on its 24h
schedule, the application did not show that the data had been
successfully submitted.

This change switches to an hourly schedule, so that we get a clearer
sense of whether or not the pipeline/updater are actually working
properly or not.