### PR TITLE
Added permissions to terraform plan against IRSA

### DIFF
--- a/resources/concourse-aws-user/main.tf
+++ b/resources/concourse-aws-user/main.tf
@@ -146,6 +146,7 @@ data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
       "eks:DescribeCluster",
+      "iam:GetOpenIDConnectProvider",
     ]
 
     resources = [


### PR DESCRIPTION
We started using IRSA (IAM Roles for Service Accounts) and concourse pipeline needs the proper IAM permissions to plan against OIDC Providers. If not specified we get: 

```console
Error: AccessDenied: User: arn:aws:iam::754256621582:user/cloud-platform/manager-concourse is not authorized to perform: iam:GetOpenIDConnectProvider on resource: arn:aws:iam::754256621582:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/999C2E911F28874577A3ADB9E5C427E9
```

