### PR TITLE
Change image version from 2.0 to "2.0"

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -26,7 +26,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: 2.0
+    tag: "2.0"
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:


### PR DESCRIPTION
Without quotes, concourse treats the image version as '2', but there
is no such tag. The quotes forces concourse to use the correct image
tag when pulling the image from docker hub.