### PR TITLE
Remove extra `trigger: false` from DNS job

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -138,7 +138,6 @@ jobs:
           trigger: true
         - get: tools-image
         - get: cloud-platform-environments-repo
-          trigger: false
       - task: run-script
         image: tools-image
         config:


### PR DESCRIPTION
I think this was a copy/paste error, and was preventing the job from
pulling the environments repo source.

Hopefully fixes
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/maintenance/jobs/delete-excess-dns/builds/1