### PR TITLE
Correct the working dir for the DNS job

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -154,7 +154,7 @@ jobs:
             K8S_CLUSTER_NAME: live-1.cloud-platform.service.justice.gov.uk
           run:
             path: /bin/sh
-            dir: cloud-platform-infrastructure-repo
+            dir: cloud-platform-environments-repo
             args:
               - -c
               - |


### PR DESCRIPTION
Another copy/paste error - the job is failing because the working
directory was specified incorrectly.