### PR TITLE
Create test destroy pipeline

### DIFF
--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -1,0 +1,148 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: master
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.18
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: keyval
+  type: keyval
+- name: after-midnight
+  type: time
+  source:
+    start: 1:00 AM
+    stop: 3:00 AM
+    location: Europe/London
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    
+- name: keyval
+  type: docker-image
+  source:
+    repository: swce/keyval-resource
+
+
+slack_failure_notification: &slack_failure_notification
+  put: slack-alert
+  params:
+    <<: *SLACK_NOTIFICATION_DEFAULTS
+    attachments:
+      - color: "danger"
+        <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+common_params: &common_params
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+  AWS_PROFILE: moj-cp
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+  KOPS_STATE_STORE: s3://cloud-platform-kops-state
+
+jobs:
+  - name: create-cluster-run-tests
+    serial: true
+    plan:
+      - in_parallel:
+        - get: after-midnight
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: tools-image
+          trigger: false 
+      - task: create-cluster-run-integration
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            <<: *common_params    
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          outputs: 
+          - name: keyval
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles 
+                export CLUSTER_NAME=xx-$(date +%d%m-%H%M)
+                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 1200"
+                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 1200
+
+                #  Output the integration-test results
+                cat ./smoke-tests/${CLUSTER_NAME}-rspec.txt
+
+                #  keyval/keyval.properties file, will pass on the cluster name info to the next job destroy-cluster
+                echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
+        on_failure: *slack_failure_notification 
+      - put: keyval
+        params:
+          file: keyval/keyval.properties   
+
+  - name: destroy-cluster
+    serial: true
+    plan:
+      - in_parallel:
+        - get: after-midnight
+          trigger: false
+          passed:
+          - create-cluster-run-tests
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: tools-image
+          trigger: false
+        - get: keyval
+          trigger: true
+          passed:
+          - create-cluster-run-tests
+      - task: destroy-test-cluster
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            <<: *common_params    
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          - name: keyval
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                #  This will export cluster name info from the previous job create-cluster-run-tests
+                export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
+
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+                echo "Executing: ./destroy-cluster.rb -n $CLUSTER_NAME"
+                ./destroy-cluster.rb --name $CLUSTER_NAME --yes
+        on_failure: *slack_failure_notification 
+
+    

--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -31,7 +31,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.15
+    tag: 1.18
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
This pipeline will run after-midnight, which create a new cluster , run integration tests and destroy the cluster.

Created it as two jobs 

1) First job will create a new cluster and run tests and pass the cluster name to second job
2) Second job triggers if the first job is passed and destroys the cluster using the cluster name provided by the first job.