### PR TITLE
Fix EKS divergence pipeline (failing ATM)

### DIFF
--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -120,7 +120,7 @@ jobs:
               - -c
               - |
                 cd terraform/cloud-platform-eks/
-                echo -e "cluster_node_count=\"4\"\nworker_node_machine_type=\"m4.large\"\nvpc_name=\"live-1\"" > manager.tfvars
+                echo -e "vpc_name=\"live-1\"" > manager.tfvars
                 cp-tools terraform check-divergence --workspace manager --var-file manager.tfvars
           outputs:
             - name: metadata        


### PR DESCRIPTION
We upgraded EKS node groups and pipeline started failing, it is because it had hardcode (as you in the PR) the nodegroups.

This PR remove these variables and take the default provided by `variables.tf`. Except for VPC_NAME, where for manager cluster is particularly different (live-1 instead of default "manager")