### PR TITLE
Remove un-used resource in divergence

### DIFF
--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -26,12 +26,6 @@ resources:
   type: time
   source:
     interval: 4h
-- name: cloud-platform-concourse-repo
-  type: git
-  source:
-    uri: https://github.com/ministryofjustice/cloud-platform-concourse.git
-    branch: master
-    git_crypt_key: ((cloud-platform-concourse-git-crypt.key))
 
 
 resource_types:


### PR DESCRIPTION
This is to fix error: invalid pipeline config:
invalid resources:
	resource 'cloud-platform-concourse-repo' is not used