### PR TITLE
Use version 2.8 of the hoodaw updater image

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -26,7 +26,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: "2.7"
+    tag: "2.8"
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:


### PR DESCRIPTION
This version has no changes over 2.7, but it keeps the image version
numbers in sync between the web application version in the environments
repository, and the updater image used here.