### PR TITLE
Get code-formatter action from "main" not "master"

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/code-formatter@master
+      - uses: ministryofjustice/github-actions/code-formatter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The default branch of the github-actions repo has been changed from
"master" to "main". This change updates the corresponding workflow file
for this repository.