### PR TITLE
Allow 2 github repos to break the rules

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -26,7 +26,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: "2.9"
+    tag: "2.10"
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:
@@ -137,6 +137,7 @@ jobs:
             GITHUB_TOKEN: ((how-out-of-date-are-we-github-token.token))
             DOCUMENTATION_SITES: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk"
             ORGANIZATION: ministryofjustice
+            REPO_EXCEPTIONS: "cloud-platform-user-guide cloud-platform-runbooks"
             REGEXP: "^cloud-platform-*"
             TEAM: WebOps
           run:


### PR DESCRIPTION
These repos have to violate some of our rules in order to publish some
documentation websites via github pages.

This change should mean they no longer show up in HOODAW as problems to
fix.