### PR TITLE
Pull the "main" branch of infra, not "master"

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -12,7 +12,7 @@ There is a bootstrap pipeline (see [`bootstrap.yaml`](live-1/main/bootstrap.yaml
 
 ### Setup
 
-To enable it for a Concourse team, copy it inside the appropriate directory (`pipelines/<cluster-name>/<team-name>/`). Make sure to adjust any values such as `CONCOURSE_CLUSTER` and `CONCOURSE_TEAM` and merge it into the master branch.
+To enable it for a Concourse team, copy it inside the appropriate directory (`pipelines/<cluster-name>/<team-name>/`). Make sure to adjust any values such as `CONCOURSE_CLUSTER` and `CONCOURSE_TEAM` and merge it into the main branch.
 
 The bootstrap pipeline uses basic authentication for `fly`. This is automatically configured for team `main` by the `helm` chart, however, the chart does not support configuring additional teams. If you are setting up the bootstrap pipeline for a different team, you need to also setup basic authentication for that team and create a kubernetes secret in the [secrets namespace](https://github.com/kubernetes/charts/tree/master/stable/concourse/#kubernetes-secrets) of your team. Refer to the pipeline configuration for the expected structure of the kubernetes secret.
 

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -11,7 +11,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
-    branch: master
+    branch: main
     git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
 - name: tools-image
   type: docker-image

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -66,7 +66,7 @@ jobs:
               - -c
               - |
                 mkdir ${HOME}/.aws
-                echo "[moj-cp]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-( 
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-(
                 export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
                 echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
                 ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test
@@ -77,4 +77,4 @@ jobs:
             attachments:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
-    
+

--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -37,7 +37,7 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
-    
+
 - name: keyval
   type: docker-image
   source:
@@ -72,17 +72,17 @@ jobs:
         - get: cloud-platform-infrastructure-repo
           trigger: false
         - get: tools-image
-          trigger: false 
+          trigger: false
       - task: create-cluster-run-integration
         image: tools-image
         config:
           platform: linux
           params:
-            <<: *common_params    
+            <<: *common_params
           inputs:
           - name: cloud-platform-infrastructure-repo
             path: ./
-          outputs: 
+          outputs:
           - name: keyval
           run:
             path: /bin/bash
@@ -90,7 +90,7 @@ jobs:
               - -c
               - |
                 mkdir ${HOME}/.aws
-                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles 
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
                 export CLUSTER_NAME=xx-$(date +%d%m-%H%M)
                 echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 1200"
                 ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 1200
@@ -100,10 +100,10 @@ jobs:
 
                 #  keyval/keyval.properties file, will pass on the cluster name info to the next job destroy-cluster
                 echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
-        on_failure: *slack_failure_notification 
+        on_failure: *slack_failure_notification
       - put: keyval
         params:
-          file: keyval/keyval.properties   
+          file: keyval/keyval.properties
 
   - name: destroy-cluster
     serial: true
@@ -126,7 +126,7 @@ jobs:
         config:
           platform: linux
           params:
-            <<: *common_params    
+            <<: *common_params
           inputs:
           - name: cloud-platform-infrastructure-repo
             path: ./
@@ -143,6 +143,6 @@ jobs:
                 echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
                 echo "Executing: ./destroy-cluster.rb -n $CLUSTER_NAME"
                 ./destroy-cluster.rb --name $CLUSTER_NAME --yes
-        on_failure: *slack_failure_notification 
+        on_failure: *slack_failure_notification
 
-    
+

--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -11,7 +11,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
-    branch: master
+    branch: main
     git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
 - name: tools-image
   type: docker-image

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -11,7 +11,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
-    branch: master
+    branch: main
     git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
 - name: cloud-platform-tools-terraform
   type: docker-image

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -116,7 +116,7 @@ jobs:
                 echo -e "vpc_name=\"live-1\"" > manager.tfvars
                 cp-tools terraform check-divergence --workspace manager --var-file manager.tfvars
           outputs:
-            - name: metadata        
+            - name: metadata
         on_failure:
           put: slack-alert
           params:
@@ -162,7 +162,7 @@ jobs:
                 cd terraform/cloud-platform/
                 cp-tools terraform check-divergence --workspace live-1
           outputs:
-            - name: metadata        
+            - name: metadata
         on_failure:
           put: slack-alert
           params:

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -11,7 +11,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
-    branch: master
+    branch: main
 - name: cloud-platform-environments-repo
   type: git
   source:

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -11,7 +11,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
-    branch: master
+    branch: main
 - name: integration-test-image
   type: docker-image
   source:


### PR DESCRIPTION
We are going to change the default branch of the
cloud-platform-infrastructure repository to be
"main" rather than "master".

This change anticipates that one.

NB: This PR should not be merged until after the default branch of the infrastructure repo. has been changed.