### PR TITLE
Use the "main" branch of the environments repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Concourse CI for the Cloud Platform
 
 In order to setup concourse initially on a cluster, you will need to have `terraform` (version >= 0.12.13), `kubectl` and `helm` installed.
 
-1. Select the name of the cluster you want to install Concourse CI on, as it appears in the terraform workspaces [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform).
+1. Select the name of the cluster you want to install Concourse CI on, as it appears in the terraform workspaces [here](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/main/terraform/cloud-platform).
 
   `kubectl config use-context <cluster-name>.cloud-platform.service.justice.gov.uk`
 

--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -12,7 +12,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
-    branch: master
+    branch: main
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
 - name: cloud-platform-terraform-gitops-repo
   type: git

--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -220,7 +220,7 @@ jobs:
                   aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
                 )
                 export branch_head_sha=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name == "head_sha") | .value')
-                export master_base_sha=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name == "base_sha") | .value')
+                export main_base_sha=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name == "base_sha") | .value')
                 bundle install --without development test
                 ./bin/plan
         on_failure:

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -16,7 +16,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
-    branch: master
+    branch: main
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
 - name: tools-image
   type: docker-image


### PR DESCRIPTION
This change anticipates switching that repo to use
"main" as the default branch. It should not be  merged until that has
happened.