### PR TITLE
Remove user guide repo from the exceptions list

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -137,7 +137,7 @@ jobs:
             GITHUB_TOKEN: ((how-out-of-date-are-we-github-token.token))
             DOCUMENTATION_SITES: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk"
             ORGANIZATION: ministryofjustice
-            REPO_EXCEPTIONS: "cloud-platform-runbooks"
+            REPO_EXCEPTIONS: "cloud-platform-runbooks cloud-platform-user-guide-publish"
             REGEXP: "^cloud-platform-*"
             TEAM: WebOps
           run:

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -137,7 +137,7 @@ jobs:
             GITHUB_TOKEN: ((how-out-of-date-are-we-github-token.token))
             DOCUMENTATION_SITES: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk"
             ORGANIZATION: ministryofjustice
-            REPO_EXCEPTIONS: "cloud-platform-user-guide cloud-platform-runbooks"
+            REPO_EXCEPTIONS: "cloud-platform-runbooks"
             REGEXP: "^cloud-platform-*"
             TEAM: WebOps
           run:


### PR DESCRIPTION
The user guide repo still *has* a master branch, 
in order to publish master/docs via github pages.
But the master branch is no longer the default
branch, and is not subject to branch protection.
So it doesn't need to be treated as an exception
anymore.

related to https://github.com/ministryofjustice/cloud-platform-user-guide/pull/339