### PR TITLE
Bump all cloud-platform-tools images to 1.19

### DIFF
--- a/pipelines/manager/main/bootstrap.yaml
+++ b/pipelines/manager/main/bootstrap.yaml
@@ -13,7 +13,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.12
+    tag: 1.19
 
 jobs:
   - name: bootstrap-pipelines

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.15
+    tag: 1.19
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.18
+    tag: 1.19
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -31,7 +31,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.18
+    tag: 1.19
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -22,7 +22,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.15
+    tag: 1.19
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/tzcronjobber.yaml
+++ b/pipelines/manager/main/tzcronjobber.yaml
@@ -2,10 +2,8 @@ resources:
 - name: tools-image
   type: docker-image
   source:
-    repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
-    tag: latest
-    aws_access_key_id: ((aws-creds.access-key-id))
-    aws_secret_access_key: ((aws-creds.secret-access-key))
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.19
 - name: cronjobber-image
   type: docker-image
   source:


### PR DESCRIPTION
The following pipelines were bumped to 1.19:
bootstrap
build-test
environments
environments-terraform
maintenance
tzcronjob

Each pipeline has a separate commit to allow a revert.