### PR TITLE
Bump version of tools image, Have tag version inside quotes

### DIFF
--- a/pipelines/manager/main/bootstrap.yaml
+++ b/pipelines/manager/main/bootstrap.yaml
@@ -13,7 +13,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.19
+    tag: "1.20"
 
 jobs:
   - name: bootstrap-pipelines

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.19
+    tag: "1.20"
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.19
+    tag: "1.20"
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: 0.2
+    tag: "0.2"
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -31,7 +31,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.19
+    tag: "1.20"
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -22,7 +22,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.19
+    tag: "1.20"
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -16,12 +16,12 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
-    tag: 1.7
+    tag: "1.7"
 - name: orphaned-namespace-checker-image
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: 2.19
+    tag: "2.19"
 - name: hoodaw-updater-image
   type: docker-image
   source:
@@ -31,7 +31,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
-    tag: 0.3
+    tag: "0.3"
 - name: slack-alert
   type: slack-notification
   source:

--- a/pipelines/manager/main/tzcronjobber.yaml
+++ b/pipelines/manager/main/tzcronjobber.yaml
@@ -3,12 +3,12 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: 1.19
+    tag: "1.20"
 - name: cronjobber-image
   type: docker-image
   source:
     repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tzcronjobber
-    tag: 0.2.0
+    tag: "0.2.0"
     aws_access_key_id: ((aws-creds.access-key-id))
     aws_secret_access_key: ((aws-creds.secret-access-key))
 jobs:


### PR DESCRIPTION
- Tags should be inside quotes to tell concourse it is a string. This could lead to referring wrong images.
- Bump tools image version to 1.20 which include cloud-platform cli