### PR TITLE
Revert auth0 tenant changes

### DIFF
--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -53,9 +53,9 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
             AWS_REGION: eu-west-2
             AWS_PROFILE: moj-cp
-            AUTH0_DOMAIN: "moj-cloud-platforms-dev.eu.auth0.com"
-            AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client_id_dev))
-            AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret_dev))
+            AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+            AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+            AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
             KOPS_STATE_STORE: s3://cloud-platform-kops-state
           inputs:
           - name: cloud-platform-infrastructure-repo

--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -57,9 +57,9 @@ common_params: &common_params
   AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
   AWS_REGION: eu-west-2
   AWS_PROFILE: moj-cp
-  AUTH0_DOMAIN: "moj-cloud-platforms-dev.eu.auth0.com"
-  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client_id_dev))
-  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret_dev))
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
   KOPS_STATE_STORE: s3://cloud-platform-kops-state
 
 jobs:


### PR DESCRIPTION
Revert auth0 tenant changes, as now we only maintain justice-cloud-platform tenant