### PR TITLE
Send daily HOODAW summary to #cloud-platform

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -39,6 +39,11 @@ resources:
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
     tag: "0.3"
+- name: dashboard-reporter-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-reporter
+    tag: "2.12"
 - name: slack-alert
   type: slack-notification
   source:
@@ -51,6 +56,10 @@ resources:
   type: time
   source:
     interval: 12h
+- name: every-24-hours
+  type: time
+  source:
+    interval: 24h
 - name: every-week
   type: time
   source:
@@ -69,6 +78,7 @@ groups:
     - integration-tests
     - eks-integration-tests
     - manual-snapshots-checker
+    - hoodaw-dashboard-reporter
 
 jobs:
   - name: orphaned-namespaces
@@ -276,3 +286,32 @@ jobs:
             attachments:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: hoodaw-dashboard-reporter
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-24-hours
+          trigger: true
+        - get: dashboard-reporter-image
+      - task: generate-report
+        image: dashboard-reporter-image
+        config:
+          platform: linux
+          outputs:
+            - name: report
+          params:
+            DASHBOARD_URL: https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk/dashboard
+            OUTPUT_FILE: report/action_items
+          run:
+            path: /app/report.rb
+        on_failure:
+          put: slack-alert
+          params:
+            channel: '#cloud-platform'
+            text_file: report/action_items
+            attachments:
+              - color: "warning"
+                title: 'How out of date are we - action required:'
+                title_link: 'https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk/dashboard'
+                footer: how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -6,6 +6,13 @@ slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
   title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
   footer: concourse.cloud-platform.service.justice.gov.uk/
 
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
 resources:
 - name: cloud-platform-infrastructure-repo
   type: git
@@ -53,13 +60,6 @@ resources:
   type: time
   source:
     interval: 6h
-
-resource_types:
-- name: slack-notification
-  type: docker-image
-  source:
-    repository: cfcommunity/slack-notification-resource
-    tag: latest
 
 groups:
 - name: reporting


### PR DESCRIPTION
This PR adds a scheduled job which, every 24 hours will use the HOODAW
dashboard reporter docker  image to send a summary of the outstanding
action items (if there are any) to #cloud-platform.

fixes https://github.com/ministryofjustice/cloud-platform/issues/1928

co-authored with @pwyborn