### PR TITLE
Update HOODAW image versions to 2.13

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -33,7 +33,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: "2.10"
+    tag: "2.13"
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:
@@ -43,7 +43,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-reporter
-    tag: "2.12"
+    tag: "2.13"
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
Version 2.12 of the dashboard-reporter image was not published
correctly. This change also updates the hoodaw updater image version, to
keep the version numbers in sync.