### PR TITLE
Create delete-completed-jobs pipleline

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -54,6 +54,7 @@ groups:
     - delete-manually-created-pods-live-1
     - delete-excess-dns
     - update-authorized-keys
+    - delete-completed-jobs
 
 jobs:
   - name: recycle-node-live-1
@@ -199,6 +200,43 @@ jobs:
               - -c
               - |
                 ./bin/update-authorized-keys.rb
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: delete-completed-jobs
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-day
+          trigger: true
+        - get: cloud-platform-environments-repo
+        - get: tools-image
+      - task: run-script-delete-completed-jobs
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                bundle install --without development test
+                ./bin/delete_completed_jobs.rb
+
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
This pipleline will run every 24hrs to execute a script to delete completed jobs which are:

not part of a Cronjobs
( default .spec.successfulJobsHistoryLimit and .spec.failedJobsHistoryLimit set already)
https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits

and job not set with ttlSecondsAfterFinished
https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/#ttl-controller

This is related to [2113](https://github.com/ministryofjustice/cloud-platform/issues/2113)