### PR TITLE
Update orphaned namespace checker image to latest release 2.20

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -28,7 +28,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: "2.19"
+    tag: "2.20"
 - name: hoodaw-updater-image
   type: docker-image
   source:


### PR DESCRIPTION
Depends on: https://github.com/ministryofjustice/cloud-platform-environments-checker/pull/28