### PR TITLE
Update v2.15 of the HOODAW updater image

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -33,7 +33,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: "2.13"
+    tag: "2.15"
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:


### PR DESCRIPTION
related to
https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/pull/41