### PR TITLE
Revert "Use HOODAW updater image 2.16"

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -33,7 +33,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: "2.16"
+    tag: "2.15"
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-concourse#286

Some helm charts (e.g. concourse, cert-manager), are not showing up on this page anymore:
https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk/helm_whatup

I'm reverting this change, in case it is related. If the missing Helm charts reappear, we'll know this was the cause.