### PR TITLE
Update delete-completed-jobs interval

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -217,7 +217,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-day
+        - get: every-hour
           trigger: true
         - get: cloud-platform-environments-repo
         - get: tools-image


### PR DESCRIPTION
Completed job count is >100 in less than 24 hrs, so updated the interval to run this job every 1 hr