### PR TITLE
Set trigger to false for environments-repo

### DIFF
--- a/pipelines/manager/main/scanning.yaml
+++ b/pipelines/manager/main/scanning.yaml
@@ -28,7 +28,7 @@ jobs:
     plan:
       - in_parallel:
         - get: cloud-platform-environments-repo
-          trigger: true
+          trigger: false
         - get: every-12-hours
           trigger: true
         - get: tools-image


### PR DESCRIPTION
Scanning is set to run every 12 hours. Setting trigger to false for "cloud-platform-environments-repo", will stop triggering pipeline on every push to environments repo.