### PR TITLE
Add on_failure alert for destroy-deleted-namespaces

### DIFF
--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -270,3 +270,10 @@ jobs:
               - |
                 bundle install --without development test
                 ./bin/auto-delete-namespace.rb
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
This will send an alert to low-priority channel