### PR TITLE
Enable TF debug logging in the cost reporter job

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -376,5 +376,6 @@ jobs:
             PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
             PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
             PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
+            TF_LOG: "DEBUG"
           run:
             path: /root/post-namespace-costs.rb


### PR DESCRIPTION
This is to try and help track down the intermittent errors with "<" when fetching tf state.
https://mojdt.slack.com/archives/C514ETYJX/p1600163387103300