### PR TITLE
Change terraform log-level to normal

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -376,6 +376,5 @@ jobs:
             PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
             PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
             PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
-            TF_LOG: "DEBUG"
           run:
             path: /root/post-namespace-costs.rb


### PR DESCRIPTION
We increased the terraform log level to DEBUG for the cost reporter pipeline, while tracking down an intermittent problem affecting this pipeline and the main "apply" pipeline. The problem was tracked down to the Pingdom API sometimes failing to give a valid response, so this extra logging is no longer necessary.