### PR TITLE
Use orphaned resources image 1.4

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -53,7 +53,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-report-orphaned-resources
-    tag: "1.3"
+    tag: "1.4"
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
Doesn't report security groups.

depends on https://github.com/ministryofjustice/cloud-platform-report-orphaned-resources/pull/7