### PR TITLE
Pass HOODAW_API_KEY env. var. to HOODAW updater

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -162,6 +162,7 @@ jobs:
             REPO_EXCEPTIONS: "cloud-platform-runbooks cloud-platform-user-guide-publish"
             REGEXP: "^cloud-platform-*"
             TEAM: WebOps
+            HOODAW_API_KEY: ((hoodaw-creds.api_key))
           run:
             path: /app/update.sh
 


### PR DESCRIPTION
The updater used to fetch the HOODAW api key directly from the
secret in the how-out-of-date-are-we namespace. However, we now
have the api key explicitly set as a secret available to concourse.

See
https://github.com/ministryofjustice/cloud-platform-terraform-concourse/pull/9

So, we can pass that value to the updater image.

A related PR will remove the code that fetches the env. var from the
namespace, so that we always get this credential in the same way, in all
pipeline jobs.
