### PR TITLE
Run namespace cost report every 12 hours

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -356,7 +356,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-24-hours
+        - get: every-12-hours
           trigger: true
         - get: cost-calculator-image
       - task: post-costs-to-hoodaw


### PR DESCRIPTION
This report currently takes ~2 hours to run, but it often fails partway through. I think this is because of contention with the apply pipeline, which also locks the terraform state of each namespace in turn.
This change runs the namespace cost report every 12 hours, instead of every 24, so that the HOODAW namespace cost report will be more up to date.
The report randomises the order in which it reports namespaces, so eventually we will get all the data, even if there is a failure on every run.