### PR TITLE
Use v1.5 of orphaned resource image

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -53,7 +53,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-report-orphaned-resources
-    tag: "1.4"
+    tag: "1.5"
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
It seems there was a problem with the 1.4 tag on docker hub - the image size is zero bytes.

I've pushed a new version (with the same code - just the tag changed to 1.5), which seems to be well-formed (110MB in size, and OS/arch reported correctly).