### PR TITLE
Use orphaned resources lister 1.6

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -53,7 +53,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-report-orphaned-resources
-    tag: "1.5"
+    tag: "1.6"
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
This excludes the default VPC

https://github.com/ministryofjustice/cloud-platform-report-orphaned-resources/pull/9