### PR TITLE
Use v1.9 of the orphaned resources image

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -53,7 +53,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-report-orphaned-resources
-    tag: "1.8"
+    tag: "1.9"
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
This has fixes for listing orphaned hosted zones

depends on https://github.com/ministryofjustice/cloud-platform-report-orphaned-resources/pull/12