### PR TITLE
Add dockerhub username and password reporting images

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -24,31 +24,43 @@ resources:
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
     tag: "1.7"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: orphaned-namespace-checker-image
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
     tag: "2.24"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cost-calculator-image
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-cost-calculator
     tag: "2.0"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: hoodaw-updater-image
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
     tag: "2.27"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
     tag: "0.3"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: dashboard-reporter-image
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-reporter
     tag: "2.13"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: orphaned-resources-reporter-image
   type: docker-image
   source:


### PR DESCRIPTION
Recently, we upgraded our DockerHub account to professional, meaning we
now have unlimited pulls for authenticated users. This change allows us
to pull the images using our bot user account.