### PR TITLE
Re-name infrastructure pipelines

### DIFF
--- a/pipelines/manager/main/cloud-platform-infrastructure.yaml
+++ b/pipelines/manager/main/cloud-platform-infrastructure.yaml
@@ -32,11 +32,11 @@ resources:
 groups:
 - name: cp-infra-terraform-automation
   jobs:
-    - plan-cloud-platform-infrastructure
-    - apply-cloud-platform-infrastructure
+    - plan-cloud-platform-components
+    - apply-cloud-platform-components
 
 jobs:
-  - name: plan-cloud-platform-infrastructure
+  - name: plan-cloud-platform-components
     serial: true
     plan:
     - get: cloud-platform-cli
@@ -82,7 +82,7 @@ jobs:
       params:
         path: pull-request
         status: success
-  - name: apply-cloud-platform-infrastructure
+  - name: apply-cloud-platform-components
     serial: true
     plan:
     - get: cloud-platform-cli


### PR DESCRIPTION
`plan-cloud-platform-infrastructure` is too vague considering we're
going to add other infrastructure pipelines in here.

For example, in the near future there will be a
`plan-cloud-platform-network`. This work just makes it easier to name
those pipelines in the future.