### PR TITLE
Add pipeline to post namespace usage to HOODAW

### DIFF
--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -1,0 +1,85 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+  silent: true
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: main
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: pipeline-tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: "1.25"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-120m
+  type: time
+  source:
+    interval: 120m
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+groups:
+- name: hoodaw
+  jobs:
+    - hoodaw-namespace-usage
+
+jobs:
+  - name: hoodaw-namespace-usage
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-120m
+          trigger: true
+        - get: cloud-platform-environments-repo
+          trigger: false
+        - get: pipeline-tools-image
+      - task: post-namespace-usage-data
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            HOODAW_HOST: https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk
+            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                kubectl config use-context ${PIPELINE_CLUSTER}
+                ./bin/post_namespace_usage_data.sh
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
Add a job to post namespace usage data to HOODAW

The reporting pipeline is getting quite crowded,
so I didn't want to add this job to that.

Instead, I'm creating a dedicated HOODAW pipeline,
with the intention of migrating all other HOODAW
jobs to it.

depends on https://github.com/ministryofjustice/cloud-platform-environments/pull/3895
required by https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/pull/61
