### PR TITLE
Add docker config auth to remaining Docker Hub images

### DIFF
--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -31,6 +31,8 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 slack_failure_notification: &slack_failure_notification
   put: slack-alert

--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -39,6 +39,8 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 - name: keyval
   type: docker-image

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -36,6 +36,8 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 groups:
 - name: divergence

--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -50,10 +50,14 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: pull-request
   type: docker-image
   source:
     repository: teliaoss/github-pr-resource
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 
 groups:

--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -36,6 +36,8 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 groups:
 - name: hoodaw

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -53,6 +53,8 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 groups:
 - name: maintenance

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -12,6 +12,8 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 resources:
 - name: cloud-platform-infrastructure-repo


### PR DESCRIPTION
Due to rate limiting on Docker Hub it is now necessary to auth on every
pull. This commit adds our bot user and password to the remaining Docker
Hub images.