### PR TITLE
Move HOODAW jobs to HOODAW pipeline

### DIFF
--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -7,6 +7,23 @@ slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
   title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
   footer: concourse.cloud-platform.service.justice.gov.uk
 
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+
+hoodaw-credentials: &HOODAW_CREDENTIALS
+  HOODAW_HOST: ((hoodaw-creds.hostname))
+  HOODAW_API_KEY: ((hoodaw-creds.api_key))
+
+aws-plus-hoodaw: &AWS_AND_HOODAW_CREDENTIALS
+  <<: *AWS_CREDENTIALS
+  <<: *HOODAW_CREDENTIALS
+
+kube-config: &KUBECONFIG_PARAMS
+  KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+  KUBECONFIG_S3_KEY: kubeconfig
+  KUBECONFIG: /tmp/kubeconfig
+
 resources:
 - name: cloud-platform-environments-repo
   type: git
@@ -154,12 +171,9 @@ jobs:
         config:
           platform: linux
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
             AWS_REGION: eu-west-2
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBECONFIG: /tmp/kubeconfig
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
             KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
             DATA_URL: ((hoodaw-creds.hostname))
             GITHUB_TOKEN: ((how-out-of-date-are-we-github-token.token))
@@ -188,11 +202,8 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            <<: *AWS_AND_HOODAW_CREDENTIALS
             KUBECONFIG: /tmp/kubeconfig
-            HOODAW_HOST: ((hoodaw-creds.hostname))
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
             PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
           run:
             path: /bin/sh
@@ -225,15 +236,12 @@ jobs:
         config:
           platform: linux
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            <<: *AWS_AND_HOODAW_CREDENTIALS
             AWS_REGION: "eu-west-2"
             KOPS_STATE_STORE: s3://cloud-platform-kops-state
             TF_STATE_BUCKET_REGION: "eu-west-1"
             TF_STATE_BUCKET_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
             TF_STATE_BUCKET_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            HOODAW_HOST: https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
           run:
             path: /bin/sh
             args:
@@ -261,10 +269,7 @@ jobs:
         config:
           platform: linux
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            HOODAW_HOST: ((hoodaw-creds.hostname))
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+            <<: *AWS_AND_HOODAW_CREDENTIALS
           run:
             path: /bin/sh
             args:
@@ -285,10 +290,7 @@ jobs:
         config:
           platform: linux
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            HOODAW_HOST: ((hoodaw-creds.hostname))
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+            <<: *AWS_AND_HOODAW_CREDENTIALS
           run:
             path: /root/post-namespace-costs.rb
 
@@ -304,15 +306,12 @@ jobs:
         config:
           platform: linux
           params:
+            <<: *KUBECONFIG_PARAMS
             KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
             KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
             KUBECONFIG_AWS_REGION: eu-west-2
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBECONFIG: /tmp/kubeconfig
             KUBE_CTX: live-1.cloud-platform.service.justice.gov.uk
-            HOODAW_HOST: ((hoodaw-creds.hostname))
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+            <<: *HOODAW_CREDENTIALS
           run:
             path: /bin/sh
             args:

--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -14,6 +14,13 @@ resources:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: main
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: hoodaw-updater-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
+    tag: "2.27"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: pipeline-tools-image
   type: docker-image
   source:
@@ -32,6 +39,10 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-hour
+  type: time
+  source:
+    interval: 60m
 - name: every-day
   type: time
   source:
@@ -53,10 +64,41 @@ resource_types:
 groups:
 - name: hoodaw
   jobs:
+    - how-out-of-date-are-we
     - hoodaw-namespace-usage
     - hoodaw-orphaned-statefiles
 
 jobs:
+  - name: how-out-of-date-are-we
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-hour
+          trigger: true
+        - get: hoodaw-updater-image
+      - task: how-out-of-date-are-we
+        image: hoodaw-updater-image
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            DATA_URL: ((hoodaw-creds.hostname))
+            GITHUB_TOKEN: ((how-out-of-date-are-we-github-token.token))
+            DOCUMENTATION_SITES: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk"
+            ORGANIZATION: ministryofjustice
+            REPO_EXCEPTIONS: "cloud-platform-runbooks cloud-platform-user-guide-publish"
+            REGEXP: "^cloud-platform-*"
+            TEAM: WebOps
+            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+          run:
+            path: /app/update.sh
+
   - name: hoodaw-namespace-usage
     serial: true
     plan:

--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -14,6 +14,13 @@ resources:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: main
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: cost-calculator-image
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-cost-calculator
+    tag: "2.0"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: orphaned-resources-reporter-image
   type: docker-image
   source:
@@ -91,6 +98,7 @@ groups:
     - hoodaw-namespace-usage
     - hoodaw-orphaned-statefiles
     - orphaned-resources-report
+    - namespace-cost-report
 
 jobs:
   - name: hoodaw-dashboard-reporter
@@ -252,4 +260,23 @@ jobs:
               - |-
                 cd /app
                 ./bin/post-data-to-hoodaw.sh
+
+  - name: namespace-cost-report
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-6-hours
+          trigger: true
+        - get: cost-calculator-image
+      - task: post-costs-to-hoodaw
+        image: cost-calculator-image
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            HOODAW_HOST: ((hoodaw-creds.hostname))
+            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+          run:
+            path: /root/post-namespace-costs.rb
 

--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -14,6 +14,13 @@ resources:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: main
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: orphaned-namespace-checker-image
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
+    tag: "2.24"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cost-calculator-image
   type: docker-image
   source:
@@ -68,6 +75,10 @@ resources:
   type: time
   source:
     interval: 6h
+- name: every-12-hours
+  type: time
+  source:
+    interval: 12h
 - name: every-day
   type: time
   source:
@@ -99,6 +110,7 @@ groups:
     - hoodaw-orphaned-statefiles
     - orphaned-resources-report
     - namespace-cost-report
+    - hosted-services-report
 
 jobs:
   - name: hoodaw-dashboard-reporter
@@ -280,3 +292,31 @@ jobs:
           run:
             path: /root/post-namespace-costs.rb
 
+  - name: hosted-services-report
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-12-hours
+          trigger: true
+        - get: orphaned-namespace-checker-image
+      - task: post-hosted-services-to-hoodaw
+        image: orphaned-namespace-checker-image
+        config:
+          platform: linux
+          params:
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG_AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CTX: live-1.cloud-platform.service.justice.gov.uk
+            HOODAW_HOST: ((hoodaw-creds.hostname))
+            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |-
+                cd /app
+                ./bin/post-data-to-hoodaw.sh

--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -14,6 +14,13 @@ resources:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: main
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: dashboard-reporter-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-reporter
+    tag: "2.13"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: hoodaw-updater-image
   type: docker-image
   source:
@@ -51,6 +58,10 @@ resources:
   type: time
   source:
     interval: 120m
+- name: every-24-hours
+  type: time
+  source:
+    interval: 24h
 
 resource_types:
 - name: slack-notification
@@ -64,11 +75,41 @@ resource_types:
 groups:
 - name: hoodaw
   jobs:
+    - hoodaw-dashboard-reporter
     - how-out-of-date-are-we
     - hoodaw-namespace-usage
     - hoodaw-orphaned-statefiles
 
 jobs:
+  - name: hoodaw-dashboard-reporter
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-24-hours
+          trigger: true
+        - get: dashboard-reporter-image
+      - task: generate-report
+        image: dashboard-reporter-image
+        config:
+          platform: linux
+          outputs:
+            - name: report
+          params:
+            DASHBOARD_URL: ((hoodaw-creds.hostname))/dashboard
+            OUTPUT_FILE: report/action_items
+          run:
+            path: /app/report.rb
+        on_failure:
+          put: slack-alert
+          params:
+            channel: '#cloud-platform'
+            text_file: report/action_items
+            attachments:
+              - color: "warning"
+                title: 'How out of date are we - action required:'
+                title_link: ((hoodaw-creds.hostname))/dashboard
+                footer: ((hoodaw-creds.hostname))
+
   - name: how-out-of-date-are-we
     serial: true
     plan:

--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -14,6 +14,13 @@ resources:
     uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: main
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: orphaned-resources-reporter-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-report-orphaned-resources
+    tag: "1.10"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: dashboard-reporter-image
   type: docker-image
   source:
@@ -50,6 +57,10 @@ resources:
   type: time
   source:
     interval: 60m
+- name: every-6-hours
+  type: time
+  source:
+    interval: 6h
 - name: every-day
   type: time
   source:
@@ -79,6 +90,7 @@ groups:
     - how-out-of-date-are-we
     - hoodaw-namespace-usage
     - hoodaw-orphaned-statefiles
+    - orphaned-resources-report
 
 jobs:
   - name: hoodaw-dashboard-reporter
@@ -216,3 +228,28 @@ jobs:
             attachments:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: orphaned-resources-report
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-6-hours
+          trigger: true
+        - get: orphaned-resources-reporter-image
+      - task: post-to-hoodaw
+        image: orphaned-resources-reporter-image
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            HOODAW_HOST: ((hoodaw-creds.hostname))
+            HOODAW_API_KEY: ((hoodaw-creds.api_key))
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |-
+                cd /app
+                ./bin/post-data-to-hoodaw.sh
+

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -35,13 +35,6 @@ resources:
     tag: "2.24"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
-- name: cost-calculator-image
-  type: docker-image
-  source:
-    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-cost-calculator
-    tag: "2.0"
-    username: ((ministryofjustice-dockerhub.dockerhub_username))
-    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:
@@ -78,7 +71,6 @@ groups:
     - integration-tests
     - eks-integration-tests
     - manual-snapshots-checker
-    - namespace-cost-report
     - hosted-services-report
 
 jobs:
@@ -259,25 +251,6 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-
-  - name: namespace-cost-report
-    serial: true
-    plan:
-      - in_parallel:
-        - get: every-6-hours
-          trigger: true
-        - get: cost-calculator-image
-      - task: post-costs-to-hoodaw
-        image: cost-calculator-image
-        config:
-          platform: linux
-          params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            HOODAW_HOST: ((hoodaw-creds.hostname))
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
-          run:
-            path: /root/post-namespace-costs.rb
 
   - name: hosted-services-report
     serial: true

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -49,13 +49,6 @@ resources:
     tag: "0.3"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
-- name: dashboard-reporter-image
-  type: docker-image
-  source:
-    repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-reporter
-    tag: "2.13"
-    username: ((ministryofjustice-dockerhub.dockerhub_username))
-    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: orphaned-resources-reporter-image
   type: docker-image
   source:
@@ -75,10 +68,6 @@ resources:
   type: time
   source:
     interval: 12h
-- name: every-24-hours
-  type: time
-  source:
-    interval: 24h
 - name: every-week
   type: time
   source:
@@ -96,7 +85,6 @@ groups:
     - integration-tests
     - eks-integration-tests
     - manual-snapshots-checker
-    - hoodaw-dashboard-reporter
     - orphaned-resources-report
     - namespace-cost-report
     - hosted-services-report
@@ -279,34 +267,6 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: hoodaw-dashboard-reporter
-    serial: true
-    plan:
-      - in_parallel:
-        - get: every-24-hours
-          trigger: true
-        - get: dashboard-reporter-image
-      - task: generate-report
-        image: dashboard-reporter-image
-        config:
-          platform: linux
-          outputs:
-            - name: report
-          params:
-            DASHBOARD_URL: ((hoodaw-creds.hostname))/dashboard
-            OUTPUT_FILE: report/action_items
-          run:
-            path: /app/report.rb
-        on_failure:
-          put: slack-alert
-          params:
-            channel: '#cloud-platform'
-            text_file: report/action_items
-            attachments:
-              - color: "warning"
-                title: 'How out of date are we - action required:'
-                title_link: ((hoodaw-creds.hostname))/dashboard
-                footer: ((hoodaw-creds.hostname))
 
   - name: orphaned-resources-report
     serial: true

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -49,13 +49,6 @@ resources:
     tag: "0.3"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
-- name: orphaned-resources-reporter-image
-  type: docker-image
-  source:
-    repository: ministryofjustice/cloud-platform-report-orphaned-resources
-    tag: "1.10"
-    username: ((ministryofjustice-dockerhub.dockerhub_username))
-    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: slack-alert
   type: slack-notification
   source:
@@ -85,7 +78,6 @@ groups:
     - integration-tests
     - eks-integration-tests
     - manual-snapshots-checker
-    - orphaned-resources-report
     - namespace-cost-report
     - hosted-services-report
 
@@ -267,30 +259,6 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-
-  - name: orphaned-resources-report
-    serial: true
-    plan:
-      - in_parallel:
-        - get: every-6-hours
-          trigger: true
-        - get: orphaned-resources-reporter-image
-      - task: post-to-hoodaw
-        image: orphaned-resources-reporter-image
-        config:
-          platform: linux
-          params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            HOODAW_HOST: ((hoodaw-creds.hostname))
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
-          run:
-            path: /bin/sh
-            args:
-              - -c
-              - |-
-                cd /app
-                ./bin/post-data-to-hoodaw.sh
 
   - name: namespace-cost-report
     serial: true

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -6,6 +6,16 @@ slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
   title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
   footer: concourse.cloud-platform.service.justice.gov.uk/
 
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+kube-config: &KUBECONFIG_PARAMS
+  KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+  KUBECONFIG_S3_KEY: kubeconfig
+  KUBECONFIG: /tmp/kubeconfig
+
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -133,12 +143,8 @@ jobs:
           inputs:
             - name: cloud-platform-infrastructure-repo
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            AWS_REGION: eu-west-2
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBECONFIG: /tmp/kubeconfig
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
             KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
             EXECUTION_CONTEXT: integration-test-pipeline
           run:
@@ -177,12 +183,8 @@ jobs:
           inputs:
             - name: cloud-platform-infrastructure-repo
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            AWS_REGION: eu-west-2
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBECONFIG: /tmp/kubeconfig
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
             KUBE_CLUSTER: manager.cloud-platform.service.justice.gov.uk
             EXECUTION_CONTEXT: integration-test-pipeline
           run:
@@ -217,9 +219,7 @@ jobs:
         config:
           platform: linux
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            AWS_REGION: eu-west-2
+            <<: *AWS_CREDENTIALS
             ALERT_WHEN_SNAPSHOTS_PERCENT_GT: 70
           run:
             path: /bin/bash

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -71,7 +71,6 @@ groups:
     - integration-tests
     - eks-integration-tests
     - manual-snapshots-checker
-    - hosted-services-report
 
 jobs:
   - name: orphaned-namespaces
@@ -250,33 +249,3 @@ jobs:
             attachments:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
-
-
-  - name: hosted-services-report
-    serial: true
-    plan:
-      - in_parallel:
-        - get: every-12-hours
-          trigger: true
-        - get: orphaned-namespace-checker-image
-      - task: post-hosted-services-to-hoodaw
-        image: orphaned-namespace-checker-image
-        config:
-          platform: linux
-          params:
-            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            KUBECONFIG_AWS_REGION: eu-west-2
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBECONFIG: /tmp/kubeconfig
-            KUBE_CTX: live-1.cloud-platform.service.justice.gov.uk
-            HOODAW_HOST: ((hoodaw-creds.hostname))
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
-          run:
-            path: /bin/sh
-            args:
-              - -c
-              - |-
-                cd /app
-                ./bin/post-data-to-hoodaw.sh

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -42,13 +42,6 @@ resources:
     tag: "2.0"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
-- name: hoodaw-updater-image
-  type: docker-image
-  source:
-    repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
-    tag: "2.27"
-    username: ((ministryofjustice-dockerhub.dockerhub_username))
-    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-tools-terraform
   type: docker-image
   source:
@@ -100,7 +93,6 @@ groups:
 - name: reporting
   jobs:
     - orphaned-namespaces
-    - how-out-of-date-are-we
     - integration-tests
     - eks-integration-tests
     - manual-snapshots-checker
@@ -152,36 +144,6 @@ jobs:
               attachments:
                 - color: "danger"
                   <<: *SLACK_ATTACHMENTS_DEFAULTS
-
-  - name: how-out-of-date-are-we
-    serial: true
-    plan:
-      - in_parallel:
-        - get: every-hour
-          trigger: true
-        - get: hoodaw-updater-image
-      - task: how-out-of-date-are-we
-        image: hoodaw-updater-image
-        config:
-          platform: linux
-          params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            AWS_REGION: eu-west-2
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBECONFIG: /tmp/kubeconfig
-            KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
-            DATA_URL: ((hoodaw-creds.hostname))
-            GITHUB_TOKEN: ((how-out-of-date-are-we-github-token.token))
-            DOCUMENTATION_SITES: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk"
-            ORGANIZATION: ministryofjustice
-            REPO_EXCEPTIONS: "cloud-platform-runbooks cloud-platform-user-guide-publish"
-            REGEXP: "^cloud-platform-*"
-            TEAM: WebOps
-            HOODAW_API_KEY: ((hoodaw-creds.api_key))
-          run:
-            path: /app/update.sh
 
   - name: integration-tests
     serial: true


### PR DESCRIPTION
This PR consolidates all HOODAW jobs into a single pipeline, which makes the reporting pipeline less crowded.

It also uses YAML anchors and aliases to avoid repetition in the reporting and hoodaw pipeline yaml files.

- Move main HOODAW job to HOODAW pipeline
- Move HOODAW dashboard job to HOODAW pipeline
- Move orphaned resources job to HOODAW pipeline
- Move namespace cost job to HOODAW pipeline
- Move hosted-services-report to HOODAW pipeline
- Refactor HOODAW pipeline yaml file
- Refactor reporting pipeline yaml file
