### PR TITLE
Use `cloud-platform-pipeline-tools` docker image

### DIFF
--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -26,7 +26,7 @@ resources:
 - name: pipeline-tools-image
   type: docker-image
   source:
-    repository: ministryofjustice/cloud-platform-tools
+    repository: ministryofjustice/cloud-platform-pipeline-tools
     tag: "1.25"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))


### PR DESCRIPTION
This is the tools image plus gems that the concourse pipeline jobs need,
which saves around 1 minute per invocation.

See this file for more information:
https://github.com/ministryofjustice/cloud-platform-tools-image/blob/main/Dockerfile.cp-env-pipeline
