### PR TITLE
Use v2.25 of the orphaned-namespace-checker image

### DIFF
--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -35,7 +35,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: "2.24"
+    tag: "2.25"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cost-calculator-image

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -42,7 +42,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: "2.24"
+    tag: "2.25"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-tools-terraform
@@ -110,6 +110,7 @@ jobs:
             TFSTATE_BUCKET_PREFIX: cloud-platform-environments/live-1.cloud-platform.service.justice.gov.uk
             GITHUB_TOKEN: ((cloud-platform-environments-pr-git-access-token))
           run:
+            user: root
             path: /app/bin/orphaned_namespaces.rb
           outputs:
             - name: output


### PR DESCRIPTION
This image runs with a non-root user, so for the reporting pipeline,
which passes output from one step as input to another, we need to tell
concourse to override the image and run the job as root. Without that,
the job fails with permission errors. I tried pre-creating and chowning
various permutations of directories, but in the end specifying `root` as
the task executor was the only way I managed to get it working.
