### PR TITLE
Revert to v2.0 of the cost calculator image

### DIFF
--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -42,7 +42,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-cost-calculator
-    tag: "2.1"
+    tag: "2.0"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: orphaned-resources-reporter-image


### PR DESCRIPTION
v2.1 fails in the concourse pipeline:
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/hoodaw/jobs/namespace-cost-report/builds/54

the error is:
```
Backend error: Exit status: 500, message: {"Type":"","Message":"runc exec: exit status 1: exec failed: container_linux.go:349: starting container process caused \"exec: \\\"/root/post-namespace-costs.rb\\\": stat /root/post-namespace-costs.rb: permission denied\"","Handle":"","ProcessID":"","Binary":""}
```
I'm not sure why. Reverting to 2.0 for now, and I'll fix this tomorrow.