### PR TITLE
Fix the namespace costs report

### DIFF
--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -42,7 +42,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-cost-calculator
-    tag: "2.0"
+    tag: "2.1"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: orphaned-resources-reporter-image
@@ -292,7 +292,7 @@ jobs:
           params:
             <<: *AWS_AND_HOODAW_CREDENTIALS
           run:
-            path: /root/post-namespace-costs.rb
+            path: /app/post-namespace-costs.rb
 
   - name: hosted-services-report
     serial: true


### PR DESCRIPTION
The problem fixed by #355 was because I hadn't updated the path to the
cost reporting ruby script from /root to /app

Once the path is updated, the job works fine with the latest (2.1)
image.
