### PR TITLE
increase frequency delete-completed-jobs

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -221,7 +221,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-hour
+        - get: every-30m
           trigger: true
         - get: cloud-platform-environments-repo
         - get: tools-image


### PR DESCRIPTION
Why [KubeletTooManyPods](https://mojdt.slack.com/archives/C8QR5FQRX/p1609842873016900). Increasing  frequency from 1 hour to 30 minutes.

However noted ticket raised for issue with the alarm itself https://github.com/ministryofjustice/cloud-platform/issues/2630:
