### PR TITLE
Change recycling-node pipeline to run evey 2 hrs between midnight and 6am

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -34,10 +34,12 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-8h
+- name: every-2h-between-midnight-6am
   type: time
   source:
-    interval: 8h
+    interval: 2h
+    start: 00:00 AM
+    stop: 6:00 AM
 - name: every-day
   type: time
   source:
@@ -73,7 +75,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-8h
+        - get: every-2h-between-midnight-6am
           trigger: true
         - get: tools-image
         - get: cloud-platform-infrastructure-repo


### PR DESCRIPTION
This is to reduce connection timeouts happening when a new node get registered to the NLB or when a healthy node becomes unhealthy.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2540