### PR TITLE
Run the orphaned namespace checker daily

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -64,11 +64,10 @@ resources:
   type: time
   source:
     interval: 12h
-- name: every-week
+- name: every-24-hours
   type: time
   source:
-    # one week in hours
-    interval: 168h
+    interval: 24h
 - name: every-6-hours
   type: time
   source:
@@ -87,7 +86,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-week
+        - get: every-24-hours
           trigger: true
         - get: orphaned-namespace-checker-image
       - task: check-environments


### PR DESCRIPTION
If someone deletes a production namespace via a PR 
in the env. repo, the 'delete namespace' pipeline 
will fail with a message that it won't delete prod 
namespaces.

This is easy to miss, especially if 
#lower-priority-alerts is noisy.

Also, if an additional, non-production namespace 
is deleted at the same time, the pipeline might 
not notice that one, if it dies because of the 
production namespace.

Running the orphaned namespace checker every day
means we should notice such issues sooner.
