### PR TITLE
Update environments-terraform.yaml (trying to fix the new k8s provider)

### DIFF
--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -83,6 +83,7 @@ jobs:
             AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
             KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
             PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
             PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
@@ -136,6 +137,7 @@ jobs:
             AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
             KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig            
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
             PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
             PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
@@ -193,6 +195,7 @@ jobs:
             AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
             KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig            
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
             PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
             PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
@@ -253,6 +256,7 @@ jobs:
             KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
             KUBECONFIG_S3_KEY: kubeconfig
             KUBE_CONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
             KUBE_CTX: live-1.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"


### PR DESCRIPTION
New kubernetes provider for terraform was released and unfortunately, it is causing problems to us. This PR should add a variable they mention is required now. More information [here](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/v2-upgrade-guide#changes-to-kubernetes-credentials-supplied-in-the-provider-block)