### PR TITLE
Remove the unused Pingdom user, password and api key

### DIFF
--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -85,9 +85,6 @@ jobs:
             KUBECONFIG: /tmp/kubeconfig
             KUBE_CONFIG_PATH: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
-            PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
-            PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
-            PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
             PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the apply script
             PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
@@ -142,9 +139,6 @@ jobs:
             KUBECONFIG: /tmp/kubeconfig
             KUBE_CONFIG_PATH: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
-            PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
-            PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
-            PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
             PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the apply script
             PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
@@ -203,9 +197,6 @@ jobs:
             KUBECONFIG: /tmp/kubeconfig
             KUBE_CONFIG_PATH: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
-            PINGDOM_USER: ((cloud-platform-environments-pingdom.pingdom_user))
-            PINGDOM_PASSWORD: ((cloud-platform-environments-pingdom.pingdom_password))
-            PINGDOM_API_KEY: ((cloud-platform-environments-pingdom.pingdom_api_key))
             PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the plan script
             PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
As we've moved to the Pingdom API V3, we no longer need the user, password and API keys. This is replaced with an API token, which is already defined.

Source:
https://docs.pingdom.com/api/
https://github.com/russellcardullo/terraform-provider-pingdom#terraform-provider-pingdom