### PR TITLE
Fix broken bootstrap pipeline

### DIFF
--- a/pipelines/manager/main/bootstrap.yaml
+++ b/pipelines/manager/main/bootstrap.yaml
@@ -13,7 +13,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: "1.41"
+    tag: "1.28"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 


### PR DESCRIPTION
This is currently broken: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/bootstrap/jobs/bootstrap-pipelines/builds/5064
We haven't upgraded the tf state to 0.14 yet.