### PR TITLE
Add every-24hr-during-workweek source

### DIFF
--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -19,10 +19,14 @@ resources:
   type: slack-notification
   source:
     url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-24-hours
+
+- name: every-24h-during-workweek
   type: time
   source:
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
     interval: 24h
+    start: 10:00 AM
+    stop: 5:00 PM
 
 resource_types:
 - name: slack-notification
@@ -43,7 +47,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-24-hours
+        - get: every-24-hours-during-workweek
           trigger: true
         - get: dashboard-reporter-image
       - task: generate-report


### PR DESCRIPTION
We currently get an alarm everyday over the weekend. We don't work out
of hours so this alarm is pointless. This change ensures the pipeline
only runs during the work week.