### PR TITLE
Update cluster_name: "live-1" in environments-live

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -97,7 +97,7 @@ jobs:
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
-            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
           run:
@@ -153,7 +153,7 @@ jobs:
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
-            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
           run:

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -94,10 +94,9 @@ jobs:
             TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
             TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
             TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
-            # the variable cluster_name here is used to get VPC info
-            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_name: "live"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
-            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
+            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
           run:
@@ -150,10 +149,9 @@ jobs:
             TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
             TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
             TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
-            # the variable cluster_name here is used to get VPC info
-            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_name: "live"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
-            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
+            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
           run:

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -94,7 +94,8 @@ jobs:
             TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
             TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
             TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
-            TF_VAR_cluster_name: "live"
+            # the variable cluster_name here is used to get VPC info
+            TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
             TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
@@ -149,7 +150,8 @@ jobs:
             TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
             TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
             TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
-            TF_VAR_cluster_name: "live"
+            # the variable cluster_name here is used to get VPC info
+            TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
             TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
@@ -205,7 +207,8 @@ jobs:
             PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
-            TF_VAR_cluster_name: "live"
+            # the variable cluster_name here is used to get VPC info
+            TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
             TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
             TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))


### PR DESCRIPTION
The variable cluster_name here is used to get VPC info,
as we are using the "live-1" VPC for the eks-live cluster.