### PR TITLE
Bump CLI version

### DIFF
--- a/pipelines/manager/main/cloud-platform-infrastructure.yaml
+++ b/pipelines/manager/main/cloud-platform-infrastructure.yaml
@@ -9,7 +9,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.9.6"
+    tag: "1.9.7"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: pull-request

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.9.6"
+    tag: "1.9.7"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: slack-alert


### PR DESCRIPTION
This fixes applying null_resources to different cluster. More details in PR: https://github.com/ministryofjustice/cloud-platform-cli/pull/101